### PR TITLE
Add .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Byte-compiled files
+__pycache__
+*.py[cod]


### PR DESCRIPTION
Running the doctests as
```
$ python -v doctests.py
```
generates multiple byte-code compiled files which should be ignored by the version control.

PS : I can add the [full version](https://github.com/github/gitignore/blob/master/Python.gitignore) of the file (which we should) if said to.