### PR TITLE
Fix for #12 Native defaultdict for 2.5+

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -232,19 +232,32 @@ def Dict(**entries):
     """
     return entries
 
-class DefaultDict(dict):
-    """Dictionary with a default value for unknown keys."""
-    def __init__(self, default):
-        self.default = default
+try:
+    from collections import defaultdict  # Introduced in 2.5
 
-    def __getitem__(self, key):
-        if key in self: return self.get(key)
-        return self.setdefault(key, copy.deepcopy(self.default))
+    def DefaultDict(default_value=None):
+        """Front-end for native 2.5 version defaultdict while
+        maintaing backward compatibility when not using a callable.
+        """
+        if (default_value is not None and not hasattr(default_value, '__call__')):
+            default_factory = lambda: copy.deepcopy(default_value)
+        else:
+            default_factory = default_value
+        return defaultdict(default_factory)
+except ImportError:
+    class DefaultDict(dict):
+        """Dictionary with a default value for unknown keys."""
+        def __init__(self, default):
+            self.default = default
 
-    def __copy__(self):
-        copy = DefaultDict(self.default)
-        copy.update(self)
-        return copy
+        def __getitem__(self, key):
+            if key in self: return self.get(key)
+            return self.setdefault(key, copy.deepcopy(self.default))
+
+        def __copy__(self):
+            copy = DefaultDict(self.default)
+            copy.update(self)
+            return copy
 
 class Struct:
     """Create an instance with argument=value slots.


### PR DESCRIPTION
**Problem**
The following is the fix as per the suggestion in #12 which suggests 
The collections.defaultdict class http://docs.python.org/library/collections.html#collections.defaultdict
could be used for Python 2.5+ rather than the method in utils.py

**Solution**:
The DefaultDict function implementation does the above and also maintains backward compatibility taking into account the fact that the native implementation in 2.5+ requires a callable for setting default values and the original implementation made use of non callables like 0 or []. The implementation allows using both a callable or  the previous method.