### PR TITLE
Pull request for bug #37.

### DIFF
--- a/games.py
+++ b/games.py
@@ -282,7 +282,7 @@ class ConnectFour(TicTacToe):
 
     def actions(self, state):
         return [(x, y) for (x, y) in state.moves
-                if y == 0 or (x, y-1) in state.board]
+                if y == 1 or (x, y-1) in state.board]
 
 __doc__ += random_tests("""
 >>> play_game(Fig52Game(), random_player, random_player)


### PR DESCRIPTION
This is a fix for [#37](https://github.com/aimacode/aima-python/issues/37).
the initial board is defined to not contain moves that have a y of zero therefor making any initial move impossible. This will return an empty list and cause a traceback.

# Solution :
The initial state of the game allows the player to make a move in the bottom most row which can be accomplished by putting y = 1. y = 0 will always return an empty list.