### PR TITLE
Fixed Links for Index of Code

### DIFF
--- a/ProjectHome.md
+++ b/ProjectHome.md
@@ -6,51 +6,51 @@ The [Subversion checkout](http://code.google.com/p/aima-python/source/checkout) 
 
 | **Fig** | **Page** | **Name (in book)** | **Code** |
 |:--------|:---------|:-------------------|:---------|
-| 2       |  32      | Environment        | [Environment](http://aima-python.googlecode.com/svn/trunk/agents.py) |
-| 2.1     |  33      | Agent              | [Agent](http://aima-python.googlecode.com/svn/trunk/agents.py) |
-| 2.3     |  34      | Table-Driven-Vacuum-Agent | [TableDrivenVacuumAgent](http://aima-python.googlecode.com/svn/trunk/agents.py) |
-| 2.7     |  45      | Table-Driven-Agent | [TableDrivenAgent](http://aima-python.googlecode.com/svn/trunk/agents.py) |
-| 2.8     |  46      | Reflex-Vacuum-Agent | [ReflexVacuumAgent](http://aima-python.googlecode.com/svn/trunk/agents.py) |
-| 2.10    |  47      | Simple-Reflex-Agent | [SimpleReflexAgent](http://aima-python.googlecode.com/svn/trunk/agents.py) |
-| 2.12    |  49      | Reflex-Agent-With-State | [ReflexAgentWithState](http://aima-python.googlecode.com/svn/trunk/agents.py) |
-| 3.1     |  61      | Simple-Problem-Solving-Agent | [SimpleProblemSolvingAgent](http://aima-python.googlecode.com/svn/trunk/search.py) |
-| 3       |  62      | Problem            | [Problem](http://aima-python.googlecode.com/svn/trunk/search.py) |
-| 3.2     |  63      | Romania            | [romania](http://aima-python.googlecode.com/svn/trunk/search.py) |
-| 3       |  69      | Node               | [Node](http://aima-python.googlecode.com/svn/trunk/search.py) |
-| 3.7     |  70      | Tree-Search        | [tree\_search](http://aima-python.googlecode.com/svn/trunk/search.py) |
-| 3       |  71      | Queue              | [Queue](http://aima-python.googlecode.com/svn/trunk/utils.py) |
-| 3.9     |  72      | Tree-Search        | [tree\_search](http://aima-python.googlecode.com/svn/trunk/search.py) |
-| 3.13    |  77      | Depth-Limited-Search | [depth\_limited\_search](http://aima-python.googlecode.com/svn/trunk/search.py) |
-| 3.14    |  79      | Iterative-Deepening-Search | [iterative\_deepening\_search](http://aima-python.googlecode.com/svn/trunk/search.py) |
-| 3.19    |  83      | Graph-Search       | [graph\_search](http://aima-python.googlecode.com/svn/trunk/search.py) |
-| 4       |  95      | Best-First-Search  | [best\_first\_graph\_search](http://aima-python.googlecode.com/svn/trunk/search.py) |
-| 4       |  97      | A`*`-Search        | [astar\_search](http://aima-python.googlecode.com/svn/trunk/search.py) |
-| 4.5     | 102      | Recursive-Best-First-Search | [recursive\_best\_first\_search](http://aima-python.googlecode.com/svn/trunk/search.py) |
-| 4.11    | 112      | Hill-Climbing      | [hill\_climbing](http://aima-python.googlecode.com/svn/trunk/search.py) |
-| 4.14    | 116      | Simulated-Annealing | [simulated\_annealing](http://aima-python.googlecode.com/svn/trunk/search.py) |
-| 4.17    | 119      | Genetic-Algorithm  | [genetic\_algorithm](http://aima-python.googlecode.com/svn/trunk/search.py) |
+| 2       |  32      | Environment        | [Environment](../master/agents.py) |
+| 2.1     |  33      | Agent              | [Agent](../master/agents.py) |
+| 2.3     |  34      | Table-Driven-Vacuum-Agent | [TableDrivenVacuumAgent](../master/agents.py) |
+| 2.7     |  45      | Table-Driven-Agent | [TableDrivenAgent](../master/agents.py) |
+| 2.8     |  46      | Reflex-Vacuum-Agent | [ReflexVacuumAgent](../master/agents.py) |
+| 2.10    |  47      | Simple-Reflex-Agent | [SimpleReflexAgent](../master/agents.py) |
+| 2.12    |  49      | Reflex-Agent-With-State | [ReflexAgentWithState](../master/agents.py) |
+| 3.1     |  61      | Simple-Problem-Solving-Agent | [SimpleProblemSolvingAgent](../master/search.py) |
+| 3       |  62      | Problem            | [Problem](../master/search.py) |
+| 3.2     |  63      | Romania            | [romania](../master/search.py) |
+| 3       |  69      | Node               | [Node](../master/search.py) |
+| 3.7     |  70      | Tree-Search        | [tree\_search](../master/search.py) |
+| 3       |  71      | Queue              | [Queue](../master/utils.py) |
+| 3.9     |  72      | Tree-Search        | [tree\_search](../master/search.py) |
+| 3.13    |  77      | Depth-Limited-Search | [depth\_limited\_search](../master/search.py) |
+| 3.14    |  79      | Iterative-Deepening-Search | [iterative\_deepening\_search](../master/search.py) |
+| 3.19    |  83      | Graph-Search       | [graph\_search](../master/search.py) |
+| 4       |  95      | Best-First-Search  | [best\_first\_graph\_search](../master/search.py) |
+| 4       |  97      | A`*`-Search        | [astar\_search](../master/search.py) |
+| 4.5     | 102      | Recursive-Best-First-Search | [recursive\_best\_first\_search](../master/search.py) |
+| 4.11    | 112      | Hill-Climbing      | [hill\_climbing](../master/search.py) |
+| 4.14    | 116      | Simulated-Annealing | [simulated\_annealing](../master/search.py) |
+| 4.17    | 119      | Genetic-Algorithm  | [genetic\_algorithm](../master/search.py) |
 | 4.20    | 126      | Online-DFS-Agent   |          |
 | 4.23    | 128      | LRTA`*`-Agent      |          |
-| 5       | 137      | CSP                | [CSP](http://aima-python.googlecode.com/svn/trunk/csp.py) |
-| 5.3     | 142      | Backtracking-Search | [backtracking\_search](http://aima-python.googlecode.com/svn/trunk/csp.py) |
-| 5.7     | 146      | AC-3               | [AC3](http://aima-python.googlecode.com/svn/trunk/csp.py) |
-| 5.8     | 151      | Min-Conflicts      | [min\_conflicts](http://aima-python.googlecode.com/svn/trunk/csp.py) |
-| 6.3     | 166      | Minimax-Decision   | [minimax\_decision](http://aima-python.googlecode.com/svn/trunk/games.py) |
-| 6.7     | 170      | Alpha-Beta-Search  | [alphabeta\_search](http://aima-python.googlecode.com/svn/trunk/games.py) |
-| 7       | 195      | KB                 | [KB](http://aima-python.googlecode.com/svn/trunk/logic.py) |
-| 7.1     | 196      | KB-Agent           | [KB\_Agent](http://aima-python.googlecode.com/svn/trunk/logic.py) |
-| 7.7     | 205      | Propositional Logic Sentence | [Expr](http://aima-python.googlecode.com/svn/trunk/logic.py) |
-| 7.10    | 209      | TT-Entails         | [tt\_entials](http://aima-python.googlecode.com/svn/trunk/logic.py) |
-| 7       | 215      | Convert to CNF     | [to\_cnf](http://aima-python.googlecode.com/svn/trunk/logic.py) |
-| 7.12    | 216      | PL-Resolution      | [pl\_resolution](http://aima-python.googlecode.com/svn/trunk/logic.py) |
-| 7.14    | 219      | PL-FC-Entails?     | [pl\_fc\_resolution](http://aima-python.googlecode.com/svn/trunk/logic.py) |
-| 7.16    | 222      | DPLL-Satisfiable?  | [dpll\_satisfiable](http://aima-python.googlecode.com/svn/trunk/logic.py) |
-| 7.17    | 223      | WalkSAT            | [WalkSAT](http://aima-python.googlecode.com/svn/trunk/logic.py) |
-| 7.19    | 226      | PL-Wumpus-Agent    | [PLWumpusAgent](http://aima-python.googlecode.com/svn/trunk/logic.py) |
-| 9       | 273      | Subst              | [subst](http://aima-python.googlecode.com/svn/trunk/logic.py) |
-| 9.1     | 278      | Unify              | [unify](http://aima-python.googlecode.com/svn/trunk/logic.py) |
-| 9.3     | 282      | FOL-FC-Ask         | [fol\_fc\_ask](http://aima-python.googlecode.com/svn/trunk/logic.py) |
-| 9.6     | 288      | FOL-BC-Ask         | [fol\_bc\_ask](http://aima-python.googlecode.com/svn/trunk/logic.py) |
+| 5       | 137      | CSP                | [CSP](../master/csp.py) |
+| 5.3     | 142      | Backtracking-Search | [backtracking\_search](../master/csp.py) |
+| 5.7     | 146      | AC-3               | [AC3](../master/csp.py) |
+| 5.8     | 151      | Min-Conflicts      | [min\_conflicts](../master/csp.py) |
+| 6.3     | 166      | Minimax-Decision   | [minimax\_decision](../master/games.py) |
+| 6.7     | 170      | Alpha-Beta-Search  | [alphabeta\_search](../master/games.py) |
+| 7       | 195      | KB                 | [KB](../master/logic.py) |
+| 7.1     | 196      | KB-Agent           | [KB\_Agent](../master/logic.py) |
+| 7.7     | 205      | Propositional Logic Sentence | [Expr](../master/logic.py) |
+| 7.10    | 209      | TT-Entails         | [tt\_entials](../master/logic.py) |
+| 7       | 215      | Convert to CNF     | [to\_cnf](../master/logic.py) |
+| 7.12    | 216      | PL-Resolution      | [pl\_resolution](../master/logic.py) |
+| 7.14    | 219      | PL-FC-Entails?     | [pl\_fc\_resolution](../master/logic.py) |
+| 7.16    | 222      | DPLL-Satisfiable?  | [dpll\_satisfiable](../master/logic.py) |
+| 7.17    | 223      | WalkSAT            | [WalkSAT](../master/logic.py) |
+| 7.19    | 226      | PL-Wumpus-Agent    | [PLWumpusAgent](../master/logic.py) |
+| 9       | 273      | Subst              | [subst](../master/logic.py) |
+| 9.1     | 278      | Unify              | [unify](../master/logic.py) |
+| 9.3     | 282      | FOL-FC-Ask         | [fol\_fc\_ask](../master/logic.py) |
+| 9.6     | 288      | FOL-BC-Ask         | [fol\_bc\_ask](../master/logic.py) |
 | 9.14    | 307      | Otter              |          |
 | 11.2    | 380      | Airport-problem    |          |
 | 11.3    | 381      | Spare-Tire-Problem |          |
@@ -65,8 +65,8 @@ The [Subversion checkout](http://code.google.com/p/aima-python/source/checkout) 
 | 12.10   | 435      | And-Or-Graph-Search |          |
 | 12.22   | 449      | Continuous-POP-Agent |          |
 | 12.23   | 450      | Doubles-tennis     |          |
-| 13.1    | 466      | DT-Agent           | [DTAgent](http://aima-python.googlecode.com/svn/trunk/probability.py) |
-| 13      | 469      | Discrete Probability Distribution | [DiscreteProbDist](http://aima-python.googlecode.com/svn/trunk/probability.py) |
+| 13.1    | 466      | DT-Agent           | [DTAgent](../master/probability.py) |
+| 13      | 469      | Discrete Probability Distribution | [DiscreteProbDist](../master/probability.py) |
 | 13.4    | 477      | Enumerate-Joint-Ask |          |
 | 14.10   | 509      | Elimination-Ask    |          |
 | 14.12   | 512      | Prior-Sample       |          |
@@ -77,9 +77,9 @@ The [Subversion checkout](http://code.google.com/p/aima-python/source/checkout) 
 | 15.6    | 552      | Fixed-Lag-Smoothing |          |
 | 15.15   | 566      | Particle-Filtering |          |
 | 16.8    | 603      | Information-Gathering-Agent |          |
-| 17.4    | 621      | Value-Iteration    | [value\_iteration](http://aima-python.googlecode.com/svn/trunk/mdp.py) |
-| 17.7    | 624      | Policy-Iteration   | [policy\_iteration](http://aima-python.googlecode.com/svn/trunk/mdp.py) |
-| 18.5    | 658      | Decision-Tree-Learning | [DecisionTreeLearner](http://aima-python.googlecode.com/svn/trunk/learning.py) |
+| 17.4    | 621      | Value-Iteration    | [value\_iteration](../master/mdp.py) |
+| 17.7    | 624      | Policy-Iteration   | [policy\_iteration](../master/mdp.py) |
+| 18.5    | 658      | Decision-Tree-Learning | [DecisionTreeLearner](../master/learning.py) |
 | 18.10   | 667      | AdaBoost           |          |
 | 18.14   | 672      | Decision-List-Learning |          |
 | 19.2    | 681      | Current-Best-Learning |          |
@@ -92,6 +92,6 @@ The [Subversion checkout](http://code.google.com/p/aima-python/source/checkout) 
 | 21.4    | 769      | Passive-TD-Agent   |          |
 | 21.8    | 776      | Q-Learning-Agent   |          |
 | 22.2    | 796      | Naive-Communicating-Agent |          |
-| 22.7    | 801      | Chart-Parse        | [Chart](http://aima-python.googlecode.com/svn/trunk/nlp.py) |
-| 23.1    | 837      | Viterbi-Segmentation | [viterbi\_segment](http://aima-python.googlecode.com/svn/trunk/text.py) |
+| 22.7    | 801      | Chart-Parse        | [Chart](../master/nlp.py) |
+| 23.1    | 837      | Viterbi-Segmentation | [viterbi\_segment](../master/text.py) |
 | 24.21   | 892      | Align              |          |


### PR DESCRIPTION
The links for code files have been modified such that they direct internally within the repository. For linking github's new guidelines (https://help.github.com/articles/relative-links-in-readmes/). This makes sure links work well even in cloned repos.

This partially solves the issue #46 but does not move the contents.
