### PR TITLE
Port utils.py to python3.5

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -1,253 +1,20 @@
 """Provide some widely useful utilities. Safe for "from utils import *".
-
 """
 
-from __future__ import generators
 import operator, math, random, copy, sys, os.path, bisect, re
-
-assert (2,5) <= sys.version_info < (3,), """\
-This code is meant for Python 2.5 through 2.7.
-You might find that the parts you care about still work in older
-Pythons or happen to work in newer ones, but you're on your own --
-edit utils.py if you want to try it."""
-
-#______________________________________________________________________________
-# Compatibility with Python 2.2, 2.3, and 2.4
-
-# The AIMA code was originally designed to run in Python 2.2 and up.
-# The first part of this file implements for Python 2.2 through 2.4
-# the parts of 2.5 that the original code relied on. Now we're
-# starting to go beyond what can be filled in this way, but here's
-# the compatibility code still since it doesn't hurt:
-
-try: bool, True, False ## Introduced in 2.3
-except NameError:
-    class bool(int):
-        "Simple implementation of Booleans, as in PEP 285"
-        def __init__(self, val): self.val = val
-        def __int__(self): return self.val
-        def __repr__(self): return ('False', 'True')[self.val]
-
-    True, False = bool(1), bool(0)
-
-try: sum ## Introduced in 2.3
-except NameError:
-    def sum(seq, start=0):
-        """Sum the elements of seq.
-        >>> sum([1, 2, 3])
-        6
-        """
-        return reduce(operator.add, seq, start)
-
-try: enumerate  ## Introduced in 2.3
-except NameError:
-    def enumerate(collection):
-        """Return an iterator that enumerates pairs of (i, c[i]). PEP 279.
-        >>> list(enumerate('abc'))
-        [(0, 'a'), (1, 'b'), (2, 'c')]
-        """
-        ## Copied from PEP 279
-        i = 0
-        it = iter(collection)
-        while 1:
-            yield (i, it.next())
-            i += 1
-
-
-try: reversed ## Introduced in 2.4
-except NameError:
-    def reversed(seq):
-        """Iterate over x in reverse order.
-        >>> list(reversed([1,2,3]))
-        [3, 2, 1]
-        """
-        if hasattr(seq, 'keys'):
-            raise TypeError("mappings do not support reverse iteration")
-        i = len(seq)
-        while i > 0:
-            i -= 1
-            yield seq[i]
-
-
-try: sorted ## Introduced in 2.4
-except NameError:
-    def sorted(seq, cmp=None, key=None, reverse=False):
-        """Copy seq and sort and return it.
-        >>> sorted([3, 1, 2])
-        [1, 2, 3]
-        """
-        seq2 = copy.copy(seq)
-        if key:
-            if cmp == None:
-                cmp = __builtins__.cmp
-            seq2.sort(lambda x,y: cmp(key(x), key(y)))
-        else:
-            if cmp == None:
-                seq2.sort()
-            else:
-                seq2.sort(cmp)
-        if reverse:
-            seq2.reverse()
-        return seq2
-
-try:
-    set, frozenset ## set builtin introduced in 2.4
-except NameError:
-    try:
-        import sets ## sets module introduced in 2.3
-        set, frozenset = sets.Set, sets.ImmutableSet
-    except (NameError, ImportError):
-        class BaseSet:
-            "set type (see http://docs.python.org/lib/types-set.html)"
-
-
-            def __init__(self, elements=[]):
-                self.dict = {}
-                for e in elements:
-                    self.dict[e] = 1
-
-            def __len__(self):
-                return len(self.dict)
-
-            def __iter__(self):
-                for e in self.dict:
-                    yield e
-
-            def __contains__(self, element):
-                return element in self.dict
-
-            def issubset(self, other):
-                for e in self.dict.keys():
-                    if e not in other:
-                        return False
-                return True
-
-            def issuperset(self, other):
-                for e in other:
-                    if e not in self:
-                        return False
-                return True
-
-
-            def union(self, other):
-                return type(self)(list(self) + list(other))
-
-            def intersection(self, other):
-                return type(self)([e for e in self.dict if e in other])
-
-            def difference(self, other):
-                return type(self)([e for e in self.dict if e not in other])
-
-            def symmetric_difference(self, other):
-                return type(self)([e for e in self.dict if e not in other] +
-                                  [e for e in other if e not in self.dict])
-
-            def copy(self):
-                return type(self)(self.dict)
-
-            def __repr__(self):
-                elements = ", ".join(map(str, self.dict))
-                return "%s([%s])" % (type(self).__name__, elements)
-
-            __le__ = issubset
-            __ge__ = issuperset
-            __or__ = union
-            __and__ = intersection
-            __sub__ = difference
-            __xor__ = symmetric_difference
-
-        class frozenset(BaseSet):
-            "A frozenset is a BaseSet that has a hash value and is immutable."
-
-            def __init__(self, elements=[]):
-                BaseSet.__init__(elements)
-                self.hash = 0
-                for e in self:
-                    self.hash |= hash(e)
-
-            def __hash__(self):
-                return self.hash
-
-        class set(BaseSet):
-            "A set is a BaseSet that does not have a hash, but is mutable."
-
-            def update(self, other):
-                for e in other:
-                    self.add(e)
-                return self
-
-            def intersection_update(self, other):
-                for e in self.dict.keys():
-                    if e not in other:
-                        self.remove(e)
-                return self
-
-            def difference_update(self, other):
-                for e in self.dict.keys():
-                    if e in other:
-                        self.remove(e)
-                return self
-
-            def symmetric_difference_update(self, other):
-                to_remove1 = [e for e in self.dict if e in other]
-                to_remove2 = [e for e in other if e in self.dict]
-                self.difference_update(to_remove1)
-                self.difference_update(to_remove2)
-                return self
-
-            def add(self, element):
-                self.dict[element] = 1
-
-            def remove(self, element):
-                del self.dict[element]
-
-            def discard(self, element):
-                if element in self.dict:
-                    del self.dict[element]
-
-            def pop(self):
-                key, val = self.dict.popitem()
-                return key
-
-            def clear(self):
-                self.dict.clear()
-
-            __ior__ = update
-            __iand__ = intersection_update
-            __isub__ = difference_update
-            __ixor__ = symmetric_difference_update
-
-
-
 
 #______________________________________________________________________________
 # Simple Data Structures: infinity, Dict, Struct
 
-infinity = 1.0e400
+infinity = float('inf')
 
-def Dict(**entries):
-    """Create a dict out of the argument=value arguments.
-    >>> Dict(a=1, b=2, c=3)
-    {'a': 1, 'c': 3, 'b': 2}
-    """
-    return entries
+Dict = dict
 
-class DefaultDict(dict):
-    """Dictionary with a default value for unknown keys."""
-    def __init__(self, default):
-        self.default = default
-
-    def __getitem__(self, key):
-        if key in self: return self.get(key)
-        return self.setdefault(key, copy.deepcopy(self.default))
-
-    def __copy__(self):
-        copy = DefaultDict(self.default)
-        copy.update(self)
-        return copy
+from collections import defaultdict as DefaultDict
 
 class Struct:
     """Create an instance with argument=value slots.
+    
     This is for making a lightweight object whose class doesn't matter."""
     def __init__(self, **entries):
         self.__dict__.update(entries)
@@ -259,11 +26,12 @@ class Struct:
             return cmp(self.__dict__, other)
 
     def __repr__(self):
-        args = ['%s=%s' % (k, repr(v)) for (k, v) in vars(self).items()]
-        return 'Struct(%s)' % ', '.join(sorted(args))
+        args = ['{!s}={!s}'.format(k, repr(v)) 
+                    for (k, v) in vars(self).items()]
 
 def update(x, **entries):
-    """Update a dict; or an object with slots; according to entries.
+    """Update a dict or an object with slots according to entries.
+    
     >>> update({'a': 1}, a=10, b=20)
     {'a': 10, 'b': 20}
     >>> update(Struct(a=1), a=10, b=20)
@@ -273,6 +41,7 @@ def update(x, **entries):
         x.update(entries)
     else:
         x.__dict__.update(entries)
+
     return x
 
 #______________________________________________________________________________
@@ -311,8 +80,7 @@ def count_if(predicate, seq):
     >>> count_if(callable, [42, None, max, min])
     2
     """
-    f = lambda count, x: count + (not not predicate(x))
-    return reduce(f, seq, 0)
+    return sum(map(lambda x: bool(predicate(x)), seq))
 
 def find_if(predicate, seq):
     """If there is an element of seq that satisfies predicate; return it.
@@ -321,7 +89,9 @@ def find_if(predicate, seq):
     >>> find_if(callable, [1, 2, 3])
     """
     for x in seq:
-        if predicate(x): return x
+        if predicate(x): 
+            return x
+
     return None
 
 def every(predicate, seq):
@@ -331,9 +101,8 @@ def every(predicate, seq):
     >>> every(callable, [min, 3])
     0
     """
-    for x in seq:
-        if not predicate(x): return False
-    return True
+
+    return all(predicate(x) for x in seq)
 
 def some(predicate, seq):
     """If some element x of seq satisfies predicate(x), return predicate(x).
@@ -342,11 +111,11 @@ def some(predicate, seq):
     >>> some(callable, [2, 3])
     0
     """
-    for x in seq:
-        px = predicate(x)
-        if px: return px
-    return False
+    elem = find_if(predicate,seq)
 
+    return predicate(elem) or False
+
+# TODO: rename to is_in or possibily add 'identity' to function name to clarify intent
 def isin(elt, seq):
     """Like (elt in seq), but compares with is, not ==.
     >>> e = []; isin(e, [1, e, 3])
@@ -354,9 +123,7 @@ def isin(elt, seq):
     >>> isin(e, [1, [], 3])
     False
     """
-    for x in seq:
-        if elt is x: return True
-    return False
+    return any(x is elt for x in seq)
 
 #______________________________________________________________________________
 # Functions on sequences of numbers
@@ -367,44 +134,31 @@ def isin(elt, seq):
 # do with ties: return the first one, return them all, or pick at random.
 
 def argmin(seq, fn):
-    """Return an element with lowest fn(seq[i]) score; tie goes to first one.
-    >>> argmin(['one', 'to', 'three'], len)
-    'to'
-    """
-    best = seq[0]; best_score = fn(best)
-    for x in seq:
-        x_score = fn(x)
-        if x_score < best_score:
-            best, best_score = x, x_score
-    return best
+    return min(seq, key=fn)
 
 def argmin_list(seq, fn):
     """Return a list of elements of seq[i] with the lowest fn(seq[i]) scores.
     >>> argmin_list(['one', 'to', 'three', 'or'], len)
     ['to', 'or']
     """
-    best_score, best = fn(seq[0]), []
-    for x in seq:
-        x_score = fn(x)
-        if x_score < best_score:
-            best, best_score = [x], x_score
-        elif x_score == best_score:
-            best.append(x)
-    return best
+    smallest_score = min(seq, key=fn)
+
+    return [elem for elem in seq if fn(elem) == smallest_score]
+
+def argmin_gen(seq, fn):
+    """Return a generator of elements of seq[i] with the lowest fn(seq[i]) scores.
+    >>> argmin_list(['one', 'to', 'three', 'or'], len)
+    ['to', 'or']
+    """
+
+    smallest_score = min(seq, key=fn)
+
+    yield from (elem for elem in seq if fn(elem) == smallest_score)
 
 def argmin_random_tie(seq, fn):
     """Return an element with lowest fn(seq[i]) score; break ties at random.
     Thus, for all s,f: argmin_random_tie(s, f) in argmin_list(s, f)"""
-    best_score = fn(seq[0]); n = 0
-    for x in seq:
-        x_score = fn(x)
-        if x_score < best_score:
-            best, best_score = x, x_score; n = 1
-        elif x_score == best_score:
-            n += 1
-            if random.randrange(n) == 0:
-                best = x
-    return best
+    return random.choice(argmin_gen(seq, fn))
 
 def argmax(seq, fn):
     """Return an element with highest fn(seq[i]) score; tie goes to first one.
@@ -420,9 +174,17 @@ def argmax_list(seq, fn):
     """
     return argmin_list(seq, lambda x: -fn(x))
 
+def argmax_gen(seq, fn):
+    """Return a generator of elements of seq[i] with the highest fn(seq[i]) scores.
+    >>> argmax_list(['one', 'three', 'seven'], len)
+    ['three', 'seven']
+    """
+    yield from argmin_gen(seq, lambda x: -fn(x))
+
 def argmax_random_tie(seq, fn):
     "Return an element with highest fn(seq[i]) score; break ties at random."
     return argmin_random_tie(seq, lambda x: -fn(x))
+
 #______________________________________________________________________________
 # Statistical and mathematical functions
 
@@ -430,58 +192,25 @@ def histogram(values, mode=0, bin_function=None):
     """Return a list of (value, count) pairs, summarizing the input values.
     Sorted by increasing value, or if mode=1, by decreasing count.
     If bin_function is given, map it over values first."""
-    if bin_function: values = map(bin_function, values)
+    if bin_function: 
+        values = map(bin_function, values)
+
     bins = {}
     for val in values:
         bins[val] = bins.get(val, 0) + 1
+
     if mode:
         return sorted(bins.items(), key=lambda x: (x[1],x[0]), reverse=True)
     else:
         return sorted(bins.items())
 
-def log2(x):
-    """Base 2 logarithm.
-    >>> log2(1024)
-    10.0
-    """
-    return math.log10(x) / math.log10(2)
-
-def mode(values):
-    """Return the most common value in the list of values.
-    >>> mode([1, 2, 3, 2])
-    2
-    """
-    return histogram(values, mode=1)[0][0]
-
-def median(values):
-    """Return the middle value, when the values are sorted.
-    If there are an odd number of elements, try to average the middle two.
-    If they can't be averaged (e.g. they are strings), choose one at random.
-    >>> median([10, 100, 11])
-    11
-    >>> median([1, 2, 3, 4])
-    2.5
-    """
-    n = len(values)
-    values = sorted(values)
-    if n % 2 == 1:
-        return values[n/2]
-    else:
-        middle2 = values[(n/2)-1:(n/2)+1]
-        try:
-            return mean(middle2)
-        except TypeError:
-            return random.choice(middle2)
-
-def mean(values):
-    """Return the arithmetic average of the values."""
-    return sum(values) / float(len(values))
+from math import log2
+from statistics import mode, median, mean, stdev
 
 def stddev(values, meanval=None):
     """The standard deviation of a set of values.
-    Pass in the mean if you already know it."""
-    if meanval is None: meanval = mean(values)
-    return math.sqrt(sum([(x - meanval)**2 for x in values]) / (len(values)-1))
+    Pass in the mean if you already know it. """
+    return stdev(values, mu=meanval)
 
 def dotproduct(X, Y):
     """Return the sum of the element-wise product of vectors x and y.
@@ -506,13 +235,15 @@ def weighted_sample_with_replacement(seq, weights, n):
     probability of each element in proportion to its corresponding
     weight."""
     sample = weighted_sampler(seq, weights)
-    return [sample() for s in range(n)]
+
+    return [sample() for _ in range(n)]
 
 def weighted_sampler(seq, weights):
     "Return a random-sample function that picks from seq weighted by weights."
     totals = []
     for w in weights:
         totals.append(w + totals[-1] if totals else w)
+
     return lambda: seq[bisect.bisect(totals, random.uniform(0, totals[-1]))]
 
 def num_or_str(x):
@@ -522,7 +253,6 @@ def num_or_str(x):
     >>> num_or_str(' 42x ')
     '42x'
     """
-    if isnumber(x): return x
     try:
         return int(x)
     except ValueError:
@@ -562,13 +292,17 @@ def turn_right(heading):
 def turn_left(heading):
     return turn_heading(heading, +1)
 
-def distance((ax, ay), (bx, by)):
+def distance(a, b):
     "The distance between two (x, y) points."
-    return math.hypot((ax - bx), (ay - by))
+    return math.hypot((a.x - b.x), (a.y - b.y))
 
-def distance2((ax, ay), (bx, by)):
+def distance_squared(a, b):
+    "The distance between two (x, y) points."
+    return (a.x - b.x)**2 + (a.y - b.y)**2
+
+def distance2(a, b):
     "The square of the distance between two (x, y) points."
-    return (ax - bx)**2 + (ay - by)**2
+    return distance_squared(a, b)
 
 def vector_clip(vector, lowest, highest):
     """Return vector, except if any element is less than the corresponding
@@ -582,11 +316,12 @@ def vector_clip(vector, lowest, highest):
 #______________________________________________________________________________
 # Misc Functions
 
-def printf(format, *args):
+def printf(format_str, *args):
     """Format args with the first argument as format string, and write.
     Return the last arg, or format itself if there are no args."""
-    sys.stdout.write(str(format) % args)
-    return if_(args, lambda: args[-1], lambda: format)
+    sys.stdout.write(str(format_str).format(*args))
+
+    return args[-1] if args else format_str
 
 def caller(n=1):
     """Return the name of the calling function n levels up in the frame stack.
@@ -598,8 +333,10 @@ def caller(n=1):
     'f'
     """
     import inspect
+
     return inspect.getouterframes(inspect.currentframe())[n][3]
 
+# TODO: Use functools.lru_cache memoization decorator
 def memoize(fn, slot=None):
     """Memoize fn: make it remember the computed value for any argument list.
     If slot is specified, store result in that slot of first argument.
@@ -617,7 +354,9 @@ def memoize(fn, slot=None):
             if not memoized_fn.cache.has_key(args):
                 memoized_fn.cache[args] = fn(*args)
             return memoized_fn.cache[args]
+
         memoized_fn.cache = {}
+
     return memoized_fn
 
 def if_(test, result, alternative):
@@ -629,17 +368,21 @@ def if_(test, result, alternative):
     'ok'
     """
     if test:
-        if callable(result): return result()
+        if callable(result): 
+            return result()
+
         return result
     else:
-        if callable(alternative): return alternative()
+        if callable(alternative): 
+            return alternative()
+
         return alternative
 
-def name(object):
+def name(obj):
     "Try to find some reasonable name for the object."
-    return (getattr(object, 'name', 0) or getattr(object, '__name__', 0)
-            or getattr(getattr(object, '__class__', 0), '__name__', 0)
-            or str(object))
+    return (getattr(obj, 'name', 0) or getattr(obj, '__name__', 0)
+            or getattr(getattr(obj, '__class__', 0), '__name__', 0)
+            or str(obj))
 
 def isnumber(x):
     "Is x a number? We say it is if it has a __int__ method."
@@ -655,22 +398,30 @@ def print_table(table, header=None, sep='   ', numfmt='%g'):
     numfmt is the format for all numbers; you might want e.g. '%6.2f'.
     (If you want different formats in different columns, don't use print_table.)
     sep is the separator between columns."""
-    justs = [if_(isnumber(x), 'rjust', 'ljust') for x in table[0]]
+    justs = ['rjust' if isnumber(x) else 'ljust' for x in table[0]]
+
     if header:
-        table = [header] + table
-    table = [[if_(isnumber(x), lambda: numfmt % x, lambda: x) for x in row]
-             for row in table]
+        table.insert(0, header)
+
+    table = [[numfmt.format(x) if isnumber(x) else x for x in row]
+                for row in table]
+
     maxlen = lambda seq: max(map(len, seq))
+
     sizes = map(maxlen, zip(*[map(str, row) for row in table]))
+
     for row in table:
-        print sep.join(getattr(str(x), j)(size)
-                       for (j, size, x) in zip(justs, sizes, row))
+        print(sep.join(getattr(str(x), j)(size) 
+                for (j, size, x) in zip(justs, sizes, row)))
 
 def AIMAFile(components, mode='r'):
     "Open a file based at the AIMA root directory."
     import utils
-    dir = os.path.dirname(utils.__file__)
-    return open(apply(os.path.join, [dir] + components), mode)
+    aima_root = os.path.dirname(utils.__file__)
+
+    aima_file = os.path.join(aima_root, *components)
+
+    return open(aima_file)
 
 def DataFile(name, mode='r'):
     "Return a file in the AIMA /data directory."
@@ -683,6 +434,7 @@ def unimplemented():
 #______________________________________________________________________________
 # Queues: Stack, FIFOQueue, PriorityQueue
 
+# TODO: Use queue.Queue
 class Queue:
     """Queue is an abstract class/interface. There are three types:
         Stack(): A Last In First Out Queue.
@@ -696,7 +448,6 @@ class Queue:
         item in q       -- does q contain item?
     Note that isinstance(Stack(), Queue) is false, because we implement stacks
     as lists.  If Python ever gets interfaces, Queue will be an interface."""
-
     def __init__(self):
         abstract
 
@@ -711,12 +462,16 @@ class FIFOQueue(Queue):
     """A First-In-First-Out Queue."""
     def __init__(self):
         self.A = []; self.start = 0
+
     def append(self, item):
         self.A.append(item)
+
     def __len__(self):
         return len(self.A) - self.start
+
     def extend(self, items):
         self.A.extend(items)
+
     def pop(self):
         e = self.A[self.start]
         self.start += 1
@@ -724,9 +479,11 @@ class FIFOQueue(Queue):
             self.A = self.A[self.start:]
             self.start = 0
         return e
+
     def __contains__(self, item):
         return item in self.A[self.start:]
 
+# TODO: Use queue.PriorityQueue
 class PriorityQueue(Queue):
     """A queue in which the minimum (or maximum) element (as determined by f and
     order) is returned first. If order is min, the item with minimum f(x) is
@@ -734,26 +491,31 @@ class PriorityQueue(Queue):
     Also supports dict-like lookup."""
     def __init__(self, order=min, f=lambda x: x):
         update(self, A=[], order=order, f=f)
+
     def append(self, item):
         bisect.insort(self.A, (self.f(item), item))
+
     def __len__(self):
         return len(self.A)
+
     def pop(self):
         if self.order == min:
             return self.A.pop(0)[1]
         else:
             return self.A.pop()[1]
+
     def __contains__(self, item):
-        return some(lambda (_, x): x == item, self.A)
+        return some(lambda _, x: x == item, self.A)
+
     def __getitem__(self, key):
         for _, item in self.A:
             if item == key:
                 return item
+
     def __delitem__(self, key):
         for i, (value, item) in enumerate(self.A):
             if item == key:
                 self.A.pop(i)
-                return
 
 ## Fig: The idea is we can define things like Fig[3,10] later.
 ## Alas, it is Fig[3,10] not Fig[3.10], because that would be the same
@@ -763,92 +525,21 @@ Fig = {}
 #______________________________________________________________________________
 # Support for doctest
 
-def ignore(x): None
+def ignore(x):
+    pass
 
 def random_tests(text):
     """Some functions are stochastic. We want to be able to write a test
     with random output.  We do that by ignoring the output."""
     def fixup(test):
-        if " = " in test:
-            return ">>> " + test
-        else:
-            return ">>> ignore(" + test + ")"
-    tests =  re.findall(">>> (.*)", text)
+        return ">>> {}".format("ignore(" + test + ")" if " = " not in test else test)
+
+    tests = re.findall(">>> (.*)", text)
     return '\n'.join(map(fixup, tests))
 
 #______________________________________________________________________________
 
 __doc__ += """
->>> d = DefaultDict(0)
->>> d['x'] += 1
->>> d['x']
-1
-
->>> d = DefaultDict([])
->>> d['x'] += [1]
->>> d['y'] += [2]
->>> d['x']
-[1]
-
->>> s = Struct(a=1, b=2)
->>> s.a
-1
->>> s.a = 3
->>> s
-Struct(a=3, b=2)
-
->>> def is_even(x):
-...     return x % 2 == 0
->>> sorted([1, 2, -3])
-[-3, 1, 2]
->>> sorted(range(10), key=is_even)
-[1, 3, 5, 7, 9, 0, 2, 4, 6, 8]
->>> sorted(range(10), lambda x,y: y-x)
-[9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
-
->>> removeall(4, [])
-[]
->>> removeall('s', 'This is a test. Was a test.')
-'Thi i a tet. Wa a tet.'
->>> removeall('s', 'Something')
-'Something'
->>> removeall('s', '')
-''
-
->>> list(reversed([]))
-[]
-
->>> count_if(is_even, [1, 2, 3, 4])
-2
->>> count_if(is_even, [])
-0
-
->>> argmax([1], lambda x: x*x)
-1
->>> argmin([1], lambda x: x*x)
-1
-
-
-# Test of memoize with slots in structures
->>> countries = [Struct(name='united states'), Struct(name='canada')]
-
-# Pretend that 'gnp' was some big hairy operation:
->>> def gnp(country):
-...     print 'calculating gnp ...'
-...     return len(country.name) * 1e10
-
->>> gnp = memoize(gnp, '_gnp')
->>> map(gnp, countries)
-calculating gnp ...
-calculating gnp ...
-[130000000000.0, 60000000000.0]
->>> countries
-[Struct(_gnp=130000000000.0, name='united states'), Struct(_gnp=60000000000.0, name='canada')]
-
-# This time we avoid re-doing the calculation
->>> map(gnp, countries)
-[130000000000.0, 60000000000.0]
-
 # Test Queues:
 >>> nums = [1, 8, 2, 7, 5, 6, -99, 99, 4, 3, 0]
 >>> def qtest(q):
@@ -882,11 +573,8 @@ calculating gnp ...
 >>> histogram(vals, 1, lambda v: round(v, -2))
 [(200.0, 6), (100.0, 3)]
 
->>> log2(1.0)
-0.0
-
 >>> def fib(n):
-...     return (n<=1 and 1) or (fib(n-1) + fib(n-2))
+...     return 1 if n < 2 else fib(n-1) + fib(n-2)
 
 >>> fib(9)
 55
@@ -907,49 +595,6 @@ calculating gnp ...
 >>> q.append(2)
 >>> q.pop(), q.pop()
 (1, 2)
-
-
->>> abc = set('abc')
->>> bcd = set('bcd')
->>> 'a' in abc
-True
->>> 'a' in bcd
-False
->>> list(abc.intersection(bcd))
-['c', 'b']
->>> list(abc.union(bcd))
-['a', 'c', 'b', 'd']
-
-## From "What's new in Python 2.4", but I added calls to sl
-
->>> def sl(x):
-...     return sorted(list(x))
-
-
->>> a = set('abracadabra')                  # form a set from a string
->>> 'z' in a                                # fast membership testing
-False
->>> sl(a)                                   # unique letters in a
-['a', 'b', 'c', 'd', 'r']
-
->>> b = set('alacazam')                     # form a second set
->>> sl(a - b)                               # letters in a but not in b
-['b', 'd', 'r']
->>> sl(a | b)                               # letters in either a or b
-['a', 'b', 'c', 'd', 'l', 'm', 'r', 'z']
->>> sl(a & b)                               # letters in both a and b
-['a', 'c']
->>> sl(a ^ b)                               # letters in a or b but not both
-['b', 'd', 'l', 'm', 'r', 'z']
-
-
->>> a.add('z')                              # add a new element
->>> a.update('wxy')                         # add multiple new elements
->>> sl(a)
-['a', 'b', 'c', 'd', 'r', 'w', 'x', 'y', 'z']
->>> a.remove('x')                           # take one element out
->>> sl(a)
-['a', 'b', 'c', 'd', 'r', 'w', 'y', 'z']
 
 >>> weighted_sample_with_replacement([], [], 0)
 []

--- a/utils_test.py
+++ b/utils_test.py
@@ -1,0 +1,38 @@
+import pytest
+
+from utils import *
+
+def test_struct_initialization():
+    s = Struct(a=1, b=2)
+
+    assert s.a == 1
+    assert s.b == 2
+
+def test_struct_assignment():
+    s = Struct(a=1)
+
+    s.a = 3
+    assert s.a == 3
+
+def test_removeall_list():
+    assert removeall(4, []) == []
+    assert removeall(4, [1,2,3,4]) == [1,2,3]
+
+def test_removeall_string():
+    assert removeall('s', '') == ''
+    assert removeall('s', 'This is a test. Was a test.') == 'Thi i a tet. Wa a tet.'
+
+def test_count_if():
+    is_odd = lambda x: x % 2
+
+    assert count_if(is_odd, []) == 0
+    assert count_if(is_odd, [1, 2, 3, 4, 5]) == 3
+
+def test_argmax():
+    assert argmax([-2, 1], lambda x: x**2) == -2
+
+def test_argmin():
+    assert argmin([-2, 1], lambda x: x**2) == 1
+
+if __name__ == '__main__':
+    pytest.main()


### PR DESCRIPTION
This PR ports utils.py to python3.5 and adds py.test tests (utils_test.py).

Changes are listed below:

- In the Roadmap it was mentioned that python2 will be kept in a different branch, so I've cleaned up some compliancy code (e.g. 'try: frozenset').
- PEP8 compliant spacing
- Use of generators when necessary
- Modifying '%' operator to 'format' method.
- Using 'print' as a function
- Moved most of the doctests at the end of the module to `utils_test.py` as py.test assertions.
- Replace loops with list/gen comprehensions whenever readable.

I replaced some of the code with the stdlib code. For example, I've removed `DefaultDict` and
replaced it with `from collections import defaultdict as DefaultDict` so that the changes are readable and not breaking. I'll group imports to the beginning of the module after a code review.

Also, in some cases in order to not break the API I've added `TODO` items.

If the changes seem reasonable, I'll extend the test suite.