### PR TITLE
Fixed pruning for first max node in aphabeta_search

### DIFF
--- a/games.py
+++ b/games.py
@@ -41,6 +41,7 @@ def alphabeta_full_search(state, game):
 
     player = game.to_move(state)
 
+    #Functions used by alphabeta
     def max_value(state, alpha, beta):
         if game.terminal_test(state):
             return game.utility(state, player)
@@ -64,9 +65,7 @@ def alphabeta_full_search(state, game):
         return v
 
     # Body of alphabeta_search:
-    return argmax(game.actions(state),
-                  lambda a: min_value(game.result(state, a),
-                                      -infinity, infinity))
+    return max_value(state, -infinity, infinity)
 
 def alphabeta_search(state, game, d=4, cutoff_test=None, eval_fn=None):
     """Search game to determine best action; use alpha-beta pruning.
@@ -74,6 +73,7 @@ def alphabeta_search(state, game, d=4, cutoff_test=None, eval_fn=None):
 
     player = game.to_move(state)
 
+    #Functions used by alphabeta
     def max_value(state, alpha, beta, depth):
         if cutoff_test(state, depth):
             return eval_fn(state)
@@ -103,9 +103,7 @@ def alphabeta_search(state, game, d=4, cutoff_test=None, eval_fn=None):
     cutoff_test = (cutoff_test or
                    (lambda state,depth: depth>d or game.terminal_test(state)))
     eval_fn = eval_fn or (lambda state: game.utility(state, player))
-    return argmax(game.actions(state),
-                  lambda a: min_value(game.result(state, a),
-                                      -infinity, infinity, 0))
+    return max_value(state, -infinity, infinity, 0)
 
 #______________________________________________________________________________
 # Players for Games


### PR DESCRIPTION
Directly using max_value instead of argmax properly prunes the first node and does more justice to the pseudo code