### PR TITLE
update utils.py to support reduce in Python 3.5

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -13,6 +13,7 @@ import random
 import os.path
 import bisect
 import re
+import functools
 
 #______________________________________________________________________________
 # Simple Data Structures: infinity, Dict, Struct
@@ -80,7 +81,7 @@ def product(numbers):
     >>> product([1,2,3,4])
     24
     """
-    return reduce(operator.mul, numbers, 1)
+    return functools.reduce(operator.mul, numbers, 1)
 
 def count_if(predicate, seq):
     """Count the number of elements of seq for which the predicate is true.


### PR DESCRIPTION
In Python 3.x the reduce function is not a built-in.It's in the functools module if it is still needed to be used.