### PR TITLE
Remove test_vector_clip() in utils_test.py

### DIFF
--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -128,10 +128,6 @@ def test_clip():
     assert [clip(x, 0, 1) for x in [-1, 0.5, 10]] == [0, 0.5, 1]
 
 
-def test_vector_clip():
-    assert vector_clip((-1, 10), (0, 0), (9, 9)) == (0, 9)
-
-
 def test_caller():
     assert caller(0) == 'caller'
 


### PR DESCRIPTION
The function, vector_clip() has moved to [`grid.py`](https://github.com/aimacode/aima-python/blob/a198cd67ca418990f8418249f246475ea09140a9/aimaPy/grid.py#L43-L47), and its corresponding test case is in [`test_grid.py`](https://github.com/aimacode/aima-python/blob/a198cd67ca418990f8418249f246475ea09140a9/tests/test_grid.py#L22-L23). Therefore, this test case is no longer valid in `utils_test.py`.