### PR TITLE
Fix a few typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ When complete, this project will have Python code for all the pseudocode algorit
 
 # Index of Code #
 
-Here is a table of algorithms, the figure and page where they appear in the book, and the file where they appear in the code. Unfortuately, this chart was made for the old second edition; and has only been partially upfdated to third edition, and not at all to fourth edition. We could use help fixing up the table, based on the figures in [algorithms.pdf](https://github.com/aimacode/aima-pseudocode/blob/master/algorithms.pdf). Empty implementations are a good place for contributors to look for an iassue.
+Here is a table of algorithms, the figure and page where they appear in the book, and the file where they appear in the code. Unfortuately, this chart was made for the old second edition; and has only been partially upfdated to third edition, and not at all to fourth edition. We could use help fixing up the table, based on the figures in [algorithms.pdf](https://github.com/aimacode/aima-pseudocode/blob/master/algorithms.pdf). Empty implementations are a good place for contributors to look for an issue.
 
 
 | **Fig** | **Name (in 3<sup>rd</sup> edition)** | **Name (in code)** | **File**
@@ -125,4 +125,4 @@ Here is a table of algorithms, the figure and page where they appear in the book
 
 # Acknowledgements
 
-Many thanks for contributions over the years. I got bug reports, corrected code, and other support from Darius Bacon, Phil Ruggera, Peng Shao, Amit Patil, Ted Nienstedt, Jim Martin, Ben Catanzariti, and others. Now that the project is in Githib, you can see the [contributors](https://github.com/aimacode/aima-python/graphs/contributors) who are doing a great job of actively improving the project. Thanks to all!
+Many thanks for contributions over the years. I got bug reports, corrected code, and other support from Darius Bacon, Phil Ruggera, Peng Shao, Amit Patil, Ted Nienstedt, Jim Martin, Ben Catanzariti, and others. Now that the project is on GitHub, you can see the [contributors](https://github.com/aimacode/aima-python/graphs/contributors) who are doing a great job of actively improving the project. Thanks to all!


### PR DESCRIPTION
Not sure if this kind of pull request is welcomed, but these typos got caught into my eyes at a first glance.

I'm sure the precise preposition is "on GitHub" rather than "in", e.g. [[1]](https://help.github.com/articles/create-a-repo/)
> On GitHub, you can store all kinds of projects in repositories.
