### PR TITLE
Made the output of play_game() a bit more verbose

### DIFF
--- a/agents.ipynb
+++ b/agents.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },

--- a/csp.ipynb
+++ b/csp.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },

--- a/games.ipynb
+++ b/games.ipynb
@@ -594,7 +594,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.0"
+   "version": "3.5.1"
   }
  },
  "nbformat": 4,

--- a/games.ipynb
+++ b/games.ipynb
@@ -48,7 +48,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -101,7 +101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -208,7 +208,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -227,44 +227,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'a2'"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "random_player(game52, 'A')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'a1'"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "random_player(game52, 'A')"
    ]
@@ -278,21 +256,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "a1\n",
-      "b1\n",
-      "c1\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print( alphabeta_player(game52, 'A') )\n",
     "print( alphabeta_player(game52, 'B') )\n",
@@ -308,44 +276,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'a1'"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "minimax_decision('A', game52)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'a1'"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "alphabeta_full_search('A', game52)"
    ]
@@ -359,9 +305,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -377,21 +323,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      ". . . \n",
-      ". . . \n",
-      ". . . \n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "ttt.display(ttt.initial)"
    ]
@@ -407,7 +343,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -433,21 +369,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "X O X \n",
-      "O . O \n",
-      "X . . \n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "ttt.display(my_state)"
    ]
@@ -461,44 +387,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(3, 3)"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "random_player(ttt, my_state)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(2, 2)"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "random_player(ttt, my_state)"
    ]
@@ -512,22 +416,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(2, 2)"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "alphabeta_player(ttt, my_state)"
    ]
@@ -541,22 +434,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "1"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "play_game(ttt, alphabeta_player, random_player)"
    ]
@@ -572,28 +454,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0\n",
-      "0\n",
-      "0\n",
-      "0\n",
-      "0\n",
-      "0\n",
-      "0\n",
-      "0\n",
-      "0\n",
-      "0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "for _ in range(10):\n",
     "    print(play_game(ttt, alphabeta_player, alphabeta_player))"
@@ -608,28 +473,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "-1\n",
-      "-1\n",
-      "-1\n",
-      "0\n",
-      "-1\n",
-      "0\n",
-      "-1\n",
-      "0\n",
-      "-1\n",
-      "-1\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "for _ in range(10):\n",
     "    print(play_game(ttt, random_player, alphabeta_player))"
@@ -644,40 +492,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      ". . . \n",
-      ". . . \n",
-      ". . . \n",
-      "Your move? (3,1)\n",
-      ". . . \n",
-      ". . O \n",
-      "X . . \n",
-      "Your move? (2,2)\n",
-      ". . . \n",
-      ". X O \n",
-      "X O . \n",
-      "Your move? (1,3)\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "1"
-      ]
-     },
-     "execution_count": 43,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "play_game(ttt, query_player, random_player)"
    ]
@@ -691,48 +510,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      ". . . \n",
-      ". . . \n",
-      ". . . \n",
-      "Your move? (1,1)\n",
-      "X . . \n",
-      ". O . \n",
-      ". . . \n",
-      "Your move? (3,3)\n",
-      "X O . \n",
-      ". O . \n",
-      ". . X \n",
-      "Your move? (3,2)\n",
-      "X O . \n",
-      ". O . \n",
-      "O X X \n",
-      "Your move? (1,3)\n",
-      "X O X \n",
-      ". O O \n",
-      "O X X \n",
-      "Your move? (2,1)\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "0"
-      ]
-     },
-     "execution_count": 44,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "play_game(ttt, query_player, alphabeta_player)"
    ]
@@ -746,104 +528,44 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "3"
-      ]
-     },
-     "execution_count": 55,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "play_game(game52, alphabeta_player, alphabeta_player)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "8"
-      ]
-     },
-     "execution_count": 56,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "play_game(game52, alphabeta_player, random_player)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "A\n",
-      "Your move? a3\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "2"
-      ]
-     },
-     "execution_count": 59,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "play_game(game52, query_player, alphabeta_player)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "B\n",
-      "Your move? b2\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "12"
-      ]
-     },
-     "execution_count": 60,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "play_game(game52, alphabeta_player, query_player)"
    ]
@@ -872,7 +594,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.4"
+   "version": "3.5.0"
   }
  },
  "nbformat": 4,

--- a/games.py
+++ b/games.py
@@ -135,7 +135,7 @@ def alphabeta_search(state, game, d=4, cutoff_test=None, eval_fn=None):
 
 def query_player(game, state):
     "Make a move by querying standard input."
-    game.display(state)
+    # game.display(state)
     move_string = input('Your move? ')
     try:
         move = eval(move_string)
@@ -157,11 +157,18 @@ def play_game(game, *players):
     """Play an n-person, move-alternating game."""
 
     state = game.initial
+    print("Initial state:")
+    game.display(state)
     while True:
         for player in players:
             move = player(game, state)
             state = game.result(state, move)
+            print("State after %s's move:" % player.__name__)
+            game.display(state)
             if game.terminal_test(state):
+                print("\nGame's over!")
+                print("Final state:")
+                game.display(state)
                 return game.utility(state, game.to_move(game.initial))
 
 # ______________________________________________________________________________

--- a/grid.ipynb
+++ b/grid.ipynb
@@ -2,19 +2,11 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "25\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import grid\n",
     "\n",

--- a/intro.ipynb
+++ b/intro.ipynb
@@ -55,7 +55,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.4"
+   "version": "3.5.1"
   }
  },
  "nbformat": 4,

--- a/learning.ipynb
+++ b/learning.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },

--- a/logic.ipynb
+++ b/logic.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },

--- a/logic.py
+++ b/logic.py
@@ -56,7 +56,7 @@ class KB:
     def ask(self, query):
         """Return a substitution that makes the query true, or,
         failing that, return False."""
-        for first(self.ask_generator(query), default=False)
+        return first(self.ask_generator(query), default=False)
 
     def ask_generator(self, query):
         "Yield all the substitutions that make query true."

--- a/mdp.ipynb
+++ b/mdp.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },

--- a/nlp.ipynb
+++ b/nlp.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },

--- a/planning.ipynb
+++ b/planning.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },

--- a/probability.ipynb
+++ b/probability.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },

--- a/rl.ipynb
+++ b/rl.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },

--- a/search.ipynb
+++ b/search.ipynb
@@ -39,7 +39,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -81,7 +81,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -131,7 +131,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -149,22 +149,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['Cat', 'Monkey']"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "bfs_node = breadth_first_search(monkey_problem)\n",
     "bfs_node.solution()"
@@ -193,22 +182,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['Dog', 'Bear', 'Monkey']"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "ucs_node = uniform_cost_search(monkey_problem)\n",
     "ucs_node.solution()"
@@ -223,22 +201,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(18, 17)"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "bfs_node.path_cost, ucs_node.path_cost"
    ]
@@ -267,7 +234,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.0"
+   "version": "3.5.1"
   }
  },
  "nbformat": 4,

--- a/text.ipynb
+++ b/text.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },


### PR DESCRIPTION
Changes:
* Prints state of the game after each player played their turn.
* Notebooks are supposed to be clear without any outputs from the execution of the code cells. Cleared the outputs in all notebooks. So, everyone, before committing notebooks, just restart the kernel by clearing all the outputs.
* fixed a typo in logic.py

And @norvig, I am trying to implement interactive TicTacToe game in notebooks. In our `query_player()` function, we have `input()` which takes the input move from the player. Shall we change the way how we take the input from user? Because in notebooks, we need to take input as on_click_event() on any object and state shouldn't be displayed as it is displaying now via `game.display(state)`. Or shall I implement another method if we are running the game from inside notebooks. In the later case we can play the game both in command line and in notebooks (interactively!). Need your inputs here.