### PR TITLE
Fix a minor error to arguments of flake8 in Travis configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
   - py.test
 
 after_success:
-  - flake8 --max-line-length 100 ignore=E121,E123,E126,E221,E222,E225,E226,E242,E701,E702,E704,E731,W503 .
+  - flake8 --max-line-length 100 --ignore=E121,E123,E126,E221,E222,E225,E226,E242,E701,E702,E704,E731,W503 .
 
 notifications:
   email: false


### PR DESCRIPTION
Just added double hyphens so that `ignore` is considered as an option and not a file, which was causing an error previously.