### PR TITLE
Fully implemented LRTA* agent with tests

### DIFF
--- a/search.py
+++ b/search.py
@@ -459,9 +459,6 @@ class OnlineDFSAgent:
     def update_state(self, percept):
         raise NotImplementedError
 
-def lrta_star_agent(s1):
-    "[Fig. 4.24]"
-    unimplemented()
 
 # ______________________________________________________________________________
 # Genetic Algorithm
@@ -646,7 +643,32 @@ Fig[4, 9] = Graph(dict(
     State_6 = dict(Suck = ['State_8'], Left = ['State_5']),
     State_7 = dict(Suck = ['State_7', 'State_3'], Right = ['State_8']),
     State_8 = dict(Suck = ['State_8', 'State_6'], Left = ['State_7'])
-))
+    ))
+
+"""
+Fig. [4.23]
+One-dimensional state space Graph
+
+"""
+
+# TODO: It's better to use some meaningful names rather
+# than Fig[4, 9] to represent graphs in figures
+
+Fig[4, 23] = Graph(dict(
+    State_1 = dict(Right = ['State_2']),
+    State_2 = dict(Right = ['State_3'], Left = ['State_1']),
+    State_3 = dict(Right = ['State_4'], Left = ['State_2']),
+    State_4 = dict(Right = ['State_5'], Left = ['State_3']),
+    State_5 = dict(Right = ['State_6'], Left = ['State_4']),
+    State_6 = dict(Left = ['State_5'])
+    ))
+Fig[4, 23].least_costs = dict(
+    State_1 = 8,
+    State_2 = 9,
+    State_3 = 2,
+    State_4 = 2,
+    State_5 = 4,
+    State_6 = 3)
 
 # Principal states and territories of Australia
 Fig[6, 1] = UndirectedGraph(dict(
@@ -654,7 +676,6 @@ Fig[6, 1] = UndirectedGraph(dict(
     SA=dict(WA=1, NT=1, Q=1, NSW=1, V=1),
     NT=dict(WA=1, Q=1),
     NSW=dict(Q=1, V=1)))
-
 Fig[6, 1].locations = dict(WA=(120, 24), NT=(135, 20), SA=(135, 30),
                            Q=(145, 20), NSW=(145, 32), T=(145, 42),
                            V=(145, 37))

--- a/search.py
+++ b/search.py
@@ -461,6 +461,39 @@ class OnlineDFSAgent:
 
 # ______________________________________________________________________________
 
+class OnlineSearchProblem(Problem):
+    """ Fig. [4.23]
+    """
+    def __init__(self, initial, goal, graph):
+        self.initial = initial
+        self.goal = goal
+        self.graph = graph
+
+    def actions(self, state):
+        return self.graph.dict[state].keys()
+
+    def output(self, state, action):
+        return self.graph.dict[state][action]
+
+    def h(self, state):
+        """
+        returns least possible cost for the given state
+        """
+        return self.graph.least_costs[state]
+
+    def c(self, s, a, s1):
+        """
+        returns a cost estimate to move from state 's' to state 's1'
+        """
+        return 1
+
+    def update_state(self, percept):
+        raise NotImplementedError
+
+    def goal_test(self, state):
+        if state == self.goal:
+            return True
+        return False
 
 
 class LRTAStarAgent:
@@ -474,41 +507,49 @@ class LRTAStarAgent:
 
     def __init__(self, problem):
         self.problem = problem
-        self.result = {}
+        # self.result = {}      # no need as we are using problem.result
         self.H = {}
         self.s = None
         self.a = None
 
-    def __call__(self, s1):
-        current_state = self.update_state(s1)
-        if self.problem.goal_test(current_state):
+    def __call__(self, s1):     # as of now s1 is a state rather than a percept
+        if self.problem.goal_test(s1):
             self.a = None
+            return(self.a)
         else:
-            if current_state not in H:
-                H[current_state] = h(current_state)
-            if s is not None:
-                self.result[(self.s, self.a)] = current_state
+            if s1 not in self.H:
+                self.H[s1] = self.problem.h(s1)
+            if self.s is not None:
+                # self.result[(self.s, self.a)] = s1    # no need as we are using problem.output
+
                 # minimum cost for action b in problem.actions(s)
-                H[s] = min([LRTA_cost(s, b, self.result[(self.s, b)], H) for b in self.problem.actions(s)])
+                self.H[self.s] = min([self.LRTA_cost(self.s, b, self.problem.output(self.s, b), self.H)
+                                    for b in self.problem.actions(self.s)])
 
-            # costs for action b in problem.actions(current_state)
-            costs = [LRTA_cost(current_state, b, result[(current_state, b)], H)
-                                    for b in self.problem.actions(current_state)]
-            # an action b in problem.actions(current_state) that minimizes costs
-            self.a = self.problem.actions(current_state)[costs.index(min(costs))]
+            # costs for action b in problem.actions(s1)
+            costs = [self.LRTA_cost(s1, b, self.problem.output(s1, b), self.H)
+                        for b in self.problem.actions(s1)]
+            # an action b in problem.actions(s1) that minimizes costs
+            self.a = list(self.problem.actions(s1))[costs.index(min(costs))]
 
-            s = current_state
-            return a
+            self.s = s1
+            return self.a
 
-    def LRTA_cost(s, a, s1, H):
+    def LRTA_cost(self, s, a, s1, H):
         """
         returns cost to move from state 's' to state 's1' plus
         estimated cost to get to goal from s1
         """
+        print(s, a, s1)
         if s1 is None:
-            return(h(s))
+            return(self.problem.h(s))
         else:
-            return(c(s, a, s1) + H[s1])
+            # sometimes we need to get H[s1] which we haven't yet added to H
+            # to replace this try, except: we can initialize H with values from problem.h
+            try:
+                return(self.problem.c(s, a, s1) + self.H[s1])
+            except:
+                return(self.problem.c(s, a, s1) + self.problem.h(s1))
 
 # ______________________________________________________________________________
 # Genetic Algorithm
@@ -702,17 +743,17 @@ One-dimensional state space Graph
 """
 
 # TODO: It's better to use some meaningful names rather
-# than Fig[4, 9] to represent graphs in figures
+# than Fig[4, 9] or Fig[6, 1] to represent graphs in figures
 
-Fig[4, 23] = Graph(dict(
-    State_1 = dict(Right = ['State_2']),
-    State_2 = dict(Right = ['State_3'], Left = ['State_1']),
-    State_3 = dict(Right = ['State_4'], Left = ['State_2']),
-    State_4 = dict(Right = ['State_5'], Left = ['State_3']),
-    State_5 = dict(Right = ['State_6'], Left = ['State_4']),
-    State_6 = dict(Left = ['State_5'])
+one_dim_state_space = Graph(dict(
+    State_1 = dict(Right = 'State_2'),
+    State_2 = dict(Right = 'State_3', Left = 'State_1'),
+    State_3 = dict(Right = 'State_4', Left = 'State_2'),
+    State_4 = dict(Right = 'State_5', Left = 'State_3'),
+    State_5 = dict(Right = 'State_6', Left = 'State_4'),
+    State_6 = dict(Left = 'State_5')
     ))
-Fig[4, 23].least_costs = dict(
+one_dim_state_space.least_costs = dict(
     State_1 = 8,
     State_2 = 9,
     State_3 = 2,

--- a/search.py
+++ b/search.py
@@ -459,6 +459,56 @@ class OnlineDFSAgent:
     def update_state(self, percept):
         raise NotImplementedError
 
+# ______________________________________________________________________________
+
+
+
+class LRTAStarAgent:
+
+    """Fig. [4.24]
+    Abstract class for LRTA*-Agent. A problem needs to be
+    provided which is an instanace of a subclass of Problem Class.
+
+    Takes a OneDimStateSpaceProblem Fig. [4.23] as a problem
+    """
+
+    def __init__(self, problem):
+        self.problem = problem
+        self.result = {}
+        self.H = {}
+        self.s = None
+        self.a = None
+
+    def __call__(self, s1):
+        current_state = self.update_state(s1)
+        if self.problem.goal_test(current_state):
+            self.a = None
+        else:
+            if current_state not in H:
+                H[current_state] = h(current_state)
+            if s is not None:
+                self.result[(self.s, self.a)] = current_state
+                # minimum cost for action b in problem.actions(s)
+                H[s] = min([LRTA_cost(s, b, self.result[(self.s, b)], H) for b in self.problem.actions(s)])
+
+            # costs for action b in problem.actions(current_state)
+            costs = [LRTA_cost(current_state, b, result[(current_state, b)], H)
+                                    for b in self.problem.actions(current_state)]
+            # an action b in problem.actions(current_state) that minimizes costs
+            self.a = self.problem.actions(current_state)[costs.index(min(costs))]
+
+            s = current_state
+            return a
+
+    def LRTA_cost(s, a, s1, H):
+        """
+        returns cost to move from state 's' to state 's1' plus
+        estimated cost to get to goal from s1
+        """
+        if s1 is None:
+            return(h(s))
+        else:
+            return(c(s, a, s1) + H[s1])
 
 # ______________________________________________________________________________
 # Genetic Algorithm

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -4,6 +4,7 @@ from search import *  # noqa
 
 romania = GraphProblem('Arad', 'Bucharest', Fig[3, 2])
 vacumm_world = GraphProblemStochastic('State_1', ['State_7', 'State_8'], Fig[4, 9])
+LRTA_world = OnlineSearchProblem('State_3', 'State_5', one_dim_state_space)
 
 
 def test_breadth_first_tree_search():
@@ -37,6 +38,19 @@ def test_and_or_graph_search():
     plan = and_or_graph_search(vacumm_world)
     assert run_plan('State_1', vacumm_world, plan)
 
+def test_LRTAStarAgent():
+    my_agent = LRTAStarAgent(LRTA_world)
+    assert my_agent('State_3') == 'Right'
+    assert my_agent('State_4') == 'Left'
+    assert my_agent('State_3') == 'Right'
+    assert my_agent('State_4') == 'Right'
+    assert my_agent('State_5') is None
+
+    my_agent = LRTAStarAgent(LRTA_world)
+    assert my_agent('State_4') == 'Left'
+
+    my_agent = LRTAStarAgent(LRTA_world)
+    assert my_agent('State_5') is None
 
 if __name__ == '__main__':
     pytest.main()


### PR DESCRIPTION
Changes:
* Adds 1-dimensional state space problem as in Fig [4.23]
* Adds OnlineSearchProblem subClass
* Adds fully functional LRTA * agent
* Adds tests for LRTA* agent

Everyone, please have a look at this code and any suggestions/enhancements are welcome.

@norvig, I need a bit of clarification here:
* Firstly, this implementation is slightly different from pseudo-code. And I have added comments where it differs from pseudo-code.
* Agent takes a 'state' as input of rather than 'percept' as I am unable to find a 'percept' which specifically identifies the state in this problem space.
* I haven't used `result[state, action]` as we can/should get that from `problem.output` (can be changed to problem.result). As `result[]` is empty while initialising, it fails for some values when `LRTA_cost(self.s, b, self.result(self.s, b), self.H)` is called. So, I have used `problem.output`. Or we can initialise the `result[]` with all the possible combinations of states & actions while initialising Agent.
* There's a try: except: block in `LRTA_cost` because `H[s1]` fails for some values when `self.H[s1]` is called as it is initialised as empty table. We can avoid this by initialising `H[]` with least_possible_costs while initialising Agent.

As of now, Agent works perfectly fine with all the test cases. But, a bit deviated from the pseudo-code. I will commit changes as you wish for the above mentioned problems.