### PR TITLE
Minor cleanup

### DIFF
--- a/grid.py
+++ b/grid.py
@@ -4,6 +4,7 @@
 # __________________________________________________________________________
 import math
 
+from utils import clip
 
 orientations = [(1, 0), (0, 1), (-1, 0), (0, -1)]
 
@@ -25,19 +26,9 @@ def distance(a, b):
     return math.hypot((a[0] - b[0]), (a[1] - b[1]))
 
 
-def distance_squared(a, b):
-    """The square of the distance between two (x, y) points."""
-    return (a[0] - b[0])**2 + (a[1] - b[1])**2
-
-
 def distance2(a, b):
     "The square of the distance between two (x, y) points."
-    return distance_squared(a, b)
-
-
-def clip(x, lowest, highest):
-    """Return x clipped to the range [lowest..highest]."""
-    return max(lowest, min(x, highest))
+    return (a[0] - b[0])**2 + (a[1] - b[1])**2
 
 
 def vector_clip(vector, lowest, highest):

--- a/learning.py
+++ b/learning.py
@@ -1,7 +1,7 @@
 """Learn to estimate functions from examples. (Chapters 18-20)"""
 
 from utils import (
-    removeall, unique, product, argmax, argmax_random_tie, mean,
+    removeall, unique, product, argmax, argmax_random_tie, mean, isclose
     dotproduct, vector_add, scalar_vector_product, weighted_sample_with_replacement,
     weighted_sampler, num_or_str, normalize, clip, sigmoid, print_table, DataFile, Fig
 )
@@ -826,7 +826,7 @@ def cross_validation_wrapper(learner, dataset, k=10, trials=1):
     while True:
         errT, errV = cross_validation(learner, size, dataset, k)
         # Check for convergence provided err_val is not empty
-        if (err_val and math.isclose(err_val[-1], errV, rel_tol=1e-6)):
+        if (err_val and isclose(err_val[-1], errV, rel_tol=1e-6)):
             best_size = size
             return learner(dataset, best_size)
 

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -14,13 +14,6 @@ def test_distance_squared():
     assert distance_squared((1, 2), (5, 5)) == 25.0
 
 
-def test_clip():
-    list_ = [clip(x, 0, 1) for x in [-1, 0.5, 10]]
-    res = [0, 0.5, 1]
-
-    assert compare_list(list_, res)
-
-
 def test_vector_clip():
     assert vector_clip((-1, 10), (0, 0), (9, 9)) == (0, 9)
 


### PR DESCRIPTION
- Replaced math.isclose with import from utils to maintain compatibility for Python 3.4
- Removed distancesquared function which was the same as distance2
- Removed duplicate definition of clip in grid.py and used import from utils instead.