### PR TITLE
Implemented QLearningAgent

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Here is a table of algorithms, the figure and page where they appear in the book
 | 19.12   | FOIL               |          |
 | 21.2    | Passive-ADP-Agent  | `PassiveADPAgent` | [`rl.py`](../master/rl.py) |
 | 21.4    | Passive-TD-Agent   | `PassiveTDAgent` | [`rl.py`](../master/rl.py) |
-| 21.8    | Q-Learning-Agent   |          |
+| 21.8    | Q-Learning-Agent   | `QLearningAgent` | [`rl.py`](../master/rl.py) |
 | \* 21.2    | Naive-Communicating-Agent |          |
 | 22.1    | HITS               |         |         |
 | 23      | Chart-Parse        | `Chart` | [`nlp.py`](../master/nlp.py) |

--- a/rl.py
+++ b/rl.py
@@ -1,8 +1,10 @@
 """Reinforcement Learning (Chapter 21)
 """
 
-import agents
+from collections import defaultdict
+from utils import argmax
 
+import agents
 import random
 
 
@@ -54,6 +56,68 @@ class PassiveTDAgent:
     def update_state(self, percept):
         ''' To be overriden in most cases. The default case
         assumes th percept to be of type (state, reward)'''
+        return percept
+
+
+class QLearningAgent:
+    """ An exploratory Q-learning agent. It avoids having to learn the transition
+        model because the Q-value of a state can be related directly to those of
+        its neighbors. [Fig. 21.8]
+    """
+    def __init__(self, mdp, Ne, Rplus, alpha=None):
+
+        self.gamma = mdp.gamma
+        self.terminals = mdp.terminals
+        self.all_act = mdp.actlist
+        self.Ne = Ne  # iteration limit in exploration function
+        self.Rplus = Rplus  # large value to assign before iteration limit
+        self.Q = defaultdict(float)
+        self.Nsa = defaultdict(float)
+        self.s = None
+        self.a = None
+        self.r = None
+
+        if alpha:
+            self.alpha = alpha
+        else:
+            self.alpha = lambda n: 1./(1+n)  # udacity video
+
+    def f(self, u, n):
+        """ Exploration function. Returns fixed Rplus untill
+        agent has visited state, action a Ne number of times.
+        Same as ADP agent in book."""
+        if n < self.Ne:
+            return self.Rplus
+        else:
+            return u
+
+    def actions_in_state(self, state):
+        """ Returns actions possible in given state.
+            Useful for max and argmax. """
+        if state in self.terminals:
+            return [None]
+        else:
+            return self.all_act
+
+    def __call__(self, percept):
+        s1, r1 = self.update_state(percept)
+        Q, Nsa, s, a, r = self.Q, self.Nsa, self.s, self.a, self.r
+        alpha, gamma, terminals, actions_in_state = self.alpha, self.gamma, self.terminals, self.actions_in_state
+        if s1 in terminals:
+            Q[(s1, None)] = r1
+        if s is not None:
+            Nsa[(s, a)] += 1
+            Q[(s, a)] += alpha(Nsa[(s, a)])*(r+gamma*max([Q[(s1, a1)] for a1 in actions_in_state(s1)])-Q[(s, a)])
+        if s1 in terminals:
+            self.s = self.a = self.r = None
+        else:
+            self.s, self.r = s1, r1
+            self.a = argmax(actions_in_state(s1), key=lambda a1: self.f(Q[(s1, a1)], Nsa[(s1, a1)]))
+        return self.a
+
+    def update_state(self, percept):
+        ''' To be overriden in most cases. The default case
+        assumes the percept to be of type (state, reward)'''
         return percept
 
 


### PR DESCRIPTION
I have tried to closely follow the pseudo-code. I have made use of s1, r1 instead of s_prime and r_prime as this convention is being followed by @SnShine  and others in their implementations. Later I will send a PR making changes to TD Agent and other parts I have implemented to make variable naming consistent.