### PR TITLE
Additional Changes for Python3 Porting

### DIFF
--- a/agents.py
+++ b/agents.py
@@ -35,8 +35,8 @@ EnvCanvas ## Canvas to display the environment of an EnvGUI
 #
 # Speed control in GUI does not have any effect -- fix it.
 
-from utils import mean
 from grid import distance2
+from statistics import mean
 
 import random
 import copy

--- a/csp.py
+++ b/csp.py
@@ -1,6 +1,6 @@
 """CSP (Constraint Satisfaction Problems) problems and solvers. (Chapter 6)."""
 
-from utils import count, first, every, argmin_random_tie
+from utils import count, first, argmin_random_tie
 import search
 
 from collections import defaultdict
@@ -107,7 +107,7 @@ class CSP(search.Problem):
         "The goal is to assign all variables, with all constraints satisfied."
         assignment = dict(state)
         return (len(assignment) == len(self.variables) and
-                every(lambda variables: self.nconflicts(variables, assignment[variables], assignment) == 0, self.variables))
+                all(self.nconflicts(variables, assignment[variables], assignment) == 0 for variables in  self.variables))
 
     # These are for constraint propagation
 
@@ -177,8 +177,7 @@ def revise(csp, Xi, Xj, removals):
     revised = False
     for x in csp.curr_domains[Xi][:]:
         # If Xi=x conflicts with Xj=y for every possible y, eliminate Xi=x
-        if every(lambda y: not csp.constraints(Xi, x, Xj, y),
-                 csp.curr_domains[Xj]):
+        if all(not csp.constraints(Xi, x, Xj, y) for y in csp.curr_domains[Xj]):
             csp.prune(Xi, x, removals)
             revised = True
     return revised

--- a/csp.py
+++ b/csp.py
@@ -98,9 +98,9 @@ class CSP(search.Problem):
             return [(var, val) for val in self.domains[var]
                     if self.nconflicts(var, val, assignment) == 0]
 
-    def result(self, state, xxx_todo_changeme):
+    def result(self, state, action):
         "Perform an action and return the new state."
-        (var, val) = xxx_todo_changeme
+        (var, val) = action
         return state + ((var, val),)
 
     def goal_test(self, state):

--- a/games.py
+++ b/games.py
@@ -289,9 +289,9 @@ class TicTacToe(Game):
         else:
             return 0
 
-    def k_in_row(self, board, move, player, xxx_todo_changeme):
+    def k_in_row(self, board, move, player, delta_x_y):
         "Return true if there is a line through move on board for player."
-        (delta_x, delta_y) = xxx_todo_changeme
+        (delta_x, delta_y) = delta_x_y
         x, y = move
         n = 0  # n is number of moves in row
         while board.get((x, y)) == player:

--- a/learning.py
+++ b/learning.py
@@ -1,7 +1,7 @@
 """Learn to estimate functions from examples. (Chapters 18-20)"""
 
 from utils import (
-    removeall, unique, product, argmax, argmax_random_tie, mean, isclose,
+    removeall, unique, product, argmax, argmax_random_tie, isclose,
     dotproduct, vector_add, scalar_vector_product, weighted_sample_with_replacement,
     weighted_sampler, num_or_str, normalize, clip, sigmoid, print_table, DataFile
 )
@@ -10,6 +10,8 @@ import copy
 import heapq
 import math
 import random
+
+from statistics import mean
 from collections import defaultdict
 
 # ______________________________________________________________________________

--- a/logic.py
+++ b/logic.py
@@ -32,7 +32,7 @@ And a few other functions:
 """
 
 from utils import (
-    removeall, unique, first, every, argmax, probability, num_or_str,
+    removeall, unique, first, argmax, probability, num_or_str,
     isnumber, issequence, Symbol, Expr, expr, subexpressions
 )
 import agents
@@ -168,7 +168,7 @@ def is_definite_clause(s):
     elif s.op == '==>':
         antecedent, consequent = s.args
         return (is_symbol(consequent.op) and
-                every(lambda arg: is_symbol(arg.op), conjuncts(antecedent)))
+                all(is_symbol(arg.op) for arg in conjuncts(antecedent)))
     else:
         return False
 

--- a/probability.py
+++ b/probability.py
@@ -2,7 +2,7 @@
 """
 
 from utils import (
-    product, every, argmax, element_wise_product, matrix_multiplication,
+    product, argmax, element_wise_product, matrix_multiplication,
     vector_to_diagonal, vector_add, scalar_vector_product, inverse_matrix,
     weighted_sample_with_replacement, rounder, isclose, probability, normalize
 )
@@ -176,7 +176,7 @@ class BayesNet:
         net, and its variable must not."""
         node = BayesNode(*node_spec)
         assert node.variable not in self.variables
-        assert every(lambda parent: parent in self.variables, node.parents)
+        assert all((parent in self.variables) for parent in node.parents)
         self.nodes.append(node)
         self.variables.append(node.variable)
         for parent in node.parents:
@@ -242,7 +242,7 @@ class BayesNode:
         assert isinstance(cpt, dict)
         for vs, p in list(cpt.items()):
             assert isinstance(vs, tuple) and len(vs) == len(parents)
-            assert every(lambda v: isinstance(v, bool), vs)
+            assert all(isinstance(v, bool) for v in vs)
             assert 0 <= p <= 1
 
         self.variable = X

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -179,9 +179,9 @@ def test_WalkSAT():
         # Sometimes WalkSat may run out of flips before finding a solution
         soln = WalkSAT(clauses)
         if soln:
-            assert every(lambda x: pl_true(x, soln), clauses)
+            assert all(pl_true(x, soln) for x in clauses)
             if single_solution:  #Cross check the solution if only one exists
-                assert every(lambda x: pl_true(x, single_solution), clauses)
+                assert all(pl_true(x, single_solution) for x in clauses)
                 assert soln == single_solution
     # Test WalkSat for problems with solution
     check_SAT([A & B, A & C])

--- a/utils.py
+++ b/utils.py
@@ -106,11 +106,6 @@ def histogram(values, mode=0, bin_function=None):
     else:
         return sorted(bins.items())
 
-def mean(numbers):
-    "The mean or average of numbers."
-    numbers = sequence(numbers)
-    return sum(numbers) / len(numbers)
-
 
 def dotproduct(X, Y):
     """Return the sum of the element-wise product of vectors X and Y."""

--- a/utils.py
+++ b/utils.py
@@ -50,13 +50,6 @@ def first(iterable, default=None):
     except TypeError:
         return next(iterable, default)
 
-
-def every(predicate, seq): # TODO: replace with all
-    """True if every element of seq satisfies predicate."""
-
-    return all(predicate(x) for x in seq)
-
-
 def is_in(elt, seq):
     """Similar to (elt in seq), but compares with 'is', not '=='."""
     return any(x is elt for x in seq)


### PR DESCRIPTION
- Replaced mean with standard lib function introduced in 3.4 			
- Replaced every() with all()
- Proper names for variables introduced in 2to3 conversion. These were introduced because Python 3 does not support unpacking of tuples in function arguments.

One more name needs to be changed in nlp.py. Since I am not familiar with that code as of now someone else can look into it.