### PR TITLE
Edited a link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Thanks for considering contributing to `aima-python`! Here is some of the work t
 
 ## New and Improved Algorithms
 
-- Implement functions that were in the third edition of the book but were not yet implemented in the code. Check the [list of pseudocode algorithms (pdf)](https://github.com/aimacode/pseudocode/blob/master/algorithms.pdf) to see what's missing.
+- Implement functions that were in the third edition of the book but were not yet implemented in the code. Check the [list of pseudocode algorithms (pdf)](https://github.com/aimacode/pseudocode/blob/master/aima3e-algorithms.pdf) to see what's missing.
 - As we finish chapters for the new fourth edition, we will share the new pseudocode in the [`aima-pseudocode`](https://github.com/aimacode/aima-pseudocode) repository, and describe what changes are necessary.
 We hope to have a `algorithm-name.md` file for each algorithm, eventually; it would be great if contributors could add some for the existing algorithms.
 - Give examples of how to use the code in the `.ipynb` file.


### PR DESCRIPTION
The link to "Pseudocode algorithm (pdf)" was pointing to https://github.com/aimacode/pseudocode/blob/master/algorithms.pdf, which was causing the 404 error. The name of the file algorithms.pdf was changed to aima3e-algorithms.pdf by @ctjoreilly in commit 80286be. Edited the link to reflect that change and point to a valid URL.