### PR TITLE
Planning

### DIFF
--- a/planning.py
+++ b/planning.py
@@ -7,7 +7,7 @@ from logic import FolKB
 
 class PDLL:
     """
-    PDLL used to deine a search problem
+    PDLL used to define a search problem
     It stores states in a knowledge base consisting of first order logic statements
     The conjunction of these logical statements completely define a state
     """
@@ -123,7 +123,7 @@ def air_cargo():
     effect_rem = [expr("In(c, p)")]
     unload = Action(expr("Unload(c, p, a)"), [precond_pos, precond_neg], [effect_add, effect_rem])
 
-    #  Load
+    #  Fly
     #  Used used 'f' instead of 'from' because 'from' is a python keyword and expr uses eval() function
     precond_pos = [expr("At(p, f)"), expr("Plane(p)"), expr("Airport(f)"), expr("Airport(to)")]
     precond_neg = []

--- a/planning.py
+++ b/planning.py
@@ -128,7 +128,7 @@ def air_cargo():
     unload = Action(expr("Unload(c, p, a)"), [precond_pos, precond_neg], [effect_add, effect_rem])
 
     #  Fly
-    #  Used used 'f' instead of 'from' because 'from' is a python keyword and expr uses eval() function
+    #  Used 'f' instead of 'from' because 'from' is a python keyword and expr uses eval() function
     precond_pos = [expr("At(p, f)"), expr("Plane(p)"), expr("Airport(f)"), expr("Airport(to)")]
     precond_neg = []
     effect_add = [expr("At(p, to)")]

--- a/planning.py
+++ b/planning.py
@@ -132,3 +132,42 @@ def air_cargo():
     fly = Action(expr("Fly(p, f, to)"), [precond_pos, precond_neg], [effect_add, effect_rem])
 
     return PDLL(init, [load, unload, fly], goal_test)
+
+
+def spare_tire():
+    init = [expr('Tire(Flat)'),
+            expr('Tire(Spare)'),
+            expr('At(Flat, Axle)'),
+            expr('At(Spare, Trunk)')]
+
+    def goal_test(kb):
+        required = [expr('At(Spare, Axle)'), expr('At(Flat, Ground)')]
+        for q in required:
+            if kb.ask(q) is False:
+                return False
+        return True
+
+    ##Actions
+    #Remove
+    precond_pos = [expr("At(obj, loc)")]
+    precond_neg = []
+    effect_add = [expr("At(obj, Ground)")]
+    effect_rem = [expr("At(obj, loc)")]
+    remove = Action(expr("Remove(obj, loc)"), [precond_pos, precond_neg], [effect_add, effect_rem])
+
+    #PutOn
+    precond_pos = [expr("Tire(t)"), expr("At(t, Ground)")]
+    precond_neg = [expr("At(Flat, Axle)")]
+    effect_add = [expr("At(t, Axle)")]
+    effect_rem = [expr("At(t, Ground)")]
+    put_on = Action(expr("PutOn(t, Axle)"), [precond_pos, precond_neg], [effect_add, effect_rem])
+
+    #LeaveOvernight
+    precond_pos = []
+    precond_neg = []
+    effect_add = []
+    effect_rem = [expr("At(Spare, Ground)"), expr("At(Spare, Axle)"), expr("At(Spare, Trunk)"),
+                  expr("At(Flat, Ground)"), expr("At(Flat, Axle)"), expr("At(Flat, Trunk)")]
+    leave_overnight = Action(expr("LeaveOvernight"), [precond_pos, precond_neg], [effect_add, effect_rem])
+
+    return PDLL(init, [remove, put_on, leave_overnight], goal_test)

--- a/planning.py
+++ b/planning.py
@@ -61,7 +61,11 @@ class Action:
 
     def substitute(self, e, args):
         """Replaces variables in expression with their respective Propostional symbol"""
-        new_args = [args[i] for x in e.args for i in range(len(self.args)) if self.args[i] == x]
+        new_args = list(e.args)
+        for num, x in enumerate(e.args):
+            for i in range(len(self.args)):
+                if self.args[i] == x:
+                    new_args[num] = args[i]
         return Expr(e.op, *new_args)
 
     def check_precond(self, kb, args):


### PR DESCRIPTION
Hi all

I implemented spare_tire planning problem using the current PDLL and Action classes in planning.py in commit 83e32c1. 

The goal_test for spare_tire fails due to a bug in the substitute method of class Action. The effect_add of spare_tire action "Remove" contains a ground atom (called "Ground"). Substitute method doesn't add the ground atoms as arguments to the expression. I have made a separate commit for this fix in d6b1946. 

There are also minor docstring changes in commit fdcc55b and 1d257fd.

Thank you