### PR TITLE
Update AC3 function in csp.py

### DIFF
--- a/csp.py
+++ b/csp.py
@@ -156,7 +156,7 @@ def AC3(csp, queue=None, removals=None):
             if not csp.curr_domains[Xi]:
                 return False
             for Xk in csp.neighbors[Xi]:
-                if Xk != Xi:
+                if Xk != Xj:
                     queue.append((Xk, Xi))
     return True
 


### PR DESCRIPTION
`if Xk != Xi:`    on line 159 should be
`if Xk != Xj:`

please check the open issue "ac3 in csp.py  #256" for the explanation and the test case.