### PR TITLE
Import turn_heading from grids.py since it is used in agents.py

### DIFF
--- a/agents.py
+++ b/agents.py
@@ -35,7 +35,7 @@ EnvCanvas ## Canvas to display the environment of an EnvGUI
 #
 # Speed control in GUI does not have any effect -- fix it.
 
-from grid import distance2
+from grid import distance2, turn_heading
 from statistics import mean
 
 import random


### PR DESCRIPTION
agents.py's XYEnvironment has turn_heading API exposed. It is internally using `turn_heading` from grids.py, but that is not imported.

This PR fixes that.

Thanks.