### PR TITLE
Fix flake8 for test files

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 100
+ignore = E121,E123,E126,E221,E222,E225,E226,E242,E701,E702,E704,E731,W503,F405

--- a/tests/test_csp.py
+++ b/tests/test_csp.py
@@ -1,5 +1,5 @@
 import pytest
-from csp import *   #noqa
+from csp import *   # noqa
 
 
 def test_csp_assign():

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -17,5 +17,6 @@ def test_distance2():
 def test_vector_clip():
     assert vector_clip((-1, 10), (0, 0), (9, 9)) == (0, 9)
 
+
 if __name__ == '__main__':
     pytest.main()

--- a/tests/test_learning.py
+++ b/tests/test_learning.py
@@ -1,4 +1,3 @@
-import pytest
 from learning import parse_csv, weighted_mode, weighted_replicate, DataSet, \
                      PluralityLearner, NaiveBayesLearner, NearestNeighborLearner
 from utils import DataFile
@@ -6,7 +5,7 @@ from utils import DataFile
 
 def test_parse_csv():
     Iris = DataFile('iris.csv').read()
-    assert parse_csv(Iris)[0] == [5.1,3.5,1.4,0.2,'setosa']
+    assert parse_csv(Iris)[0] == [5.1, 3.5, 1.4, 0.2, 'setosa']
 
 
 def test_weighted_mode():
@@ -16,20 +15,23 @@ def test_weighted_mode():
 def test_weighted_replicate():
     assert weighted_replicate('ABC', [1, 2, 1], 4) == ['A', 'B', 'B', 'C']
 
+
 def test_plurality_learner():
     zoo = DataSet(name="zoo")
 
     pL = PluralityLearner(zoo)
     assert pL([]) == "mammal"
 
+
 def test_naive_bayes():
     iris = DataSet(name="iris")
 
     nB = NaiveBayesLearner(iris)
-    assert nB([5,3,1,0.1]) == "setosa"
+    assert nB([5, 3, 1, 0.1]) == "setosa"
+
 
 def test_k_nearest_neighbors():
     iris = DataSet(name="iris")
 
-    kNN = NearestNeighborLearner(iris,k=3)
-    assert kNN([5,3,1,0.1]) == "setosa"
+    kNN = NearestNeighborLearner(iris, k=3)
+    assert kNN([5, 3, 1, 0.1]) == "setosa"

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1,6 +1,6 @@
 import pytest
-from logic import *
-from utils import expr_handle_infix_ops, count
+from logic import *  # noqa
+from utils import expr_handle_infix_ops, count, Symbol
 
 
 def test_expr():
@@ -56,10 +56,10 @@ def test_KB_wumpus():
     assert kb_wumpus.ask(~P[1, 2]) == {}
 
     # Statement: There is a pit in [2,2].
-    assert kb_wumpus.ask(P[2, 2]) == False
+    assert kb_wumpus.ask(P[2, 2]) is False
 
     # Statement: There is a pit in [3,1].
-    assert kb_wumpus.ask(P[3, 1]) == False
+    assert kb_wumpus.ask(P[3, 1]) is False
 
     # Statement: Neither [1,2] nor [2,1] contains a pit.
     assert kb_wumpus.ask(~P[1, 2] & ~P[2, 1]) == {}
@@ -112,7 +112,7 @@ def test_dpll():
                              & (~D | ~F) & (B | ~C | D) & (A | ~E | F) & (~A | E | D))
             == {B: False, C: True, A: True, F: False, D: True, E: False})
     assert dpll_satisfiable(A & ~B) == {A: True, B: False}
-    assert dpll_satisfiable(P & ~P) == False
+    assert dpll_satisfiable(P & ~P) is False
 
 
 def test_unify():
@@ -159,7 +159,7 @@ def test_move_not_inwards():
 def test_to_cnf():
     assert (repr(to_cnf(wumpus_world_inference & ~expr('~P12'))) ==
             "((~P12 | B11) & (~P21 | B11) & (P12 | P21 | ~B11) & ~B11 & P12)")
-    assert repr(to_cnf((P&Q) | (~P & ~Q))) == '((~P | P) & (~Q | P) & (~P | Q) & (~Q | Q))'
+    assert repr(to_cnf((P & Q) | (~P & ~Q))) == '((~P | P) & (~Q | P) & (~P | Q) & (~Q | Q))'
     assert repr(to_cnf("B <=> (P1 | P2)")) == '((~P1 | B) & (~P2 | B) & (P1 | P2 | ~B))'
     assert repr(to_cnf("a | (b & c) | d")) == '((b | a | d) & (c | a | d))'
     assert repr(to_cnf("A & (B | (D & E))")) == '(A & (D | B) & (E | B))'
@@ -169,7 +169,7 @@ def test_to_cnf():
 def test_standardize_variables():
     e = expr('F(a, b, c) & G(c, A, 23)')
     assert len(variables(standardize_variables(e))) == 3
-    #assert variables(e).intersection(variables(standardize_variables(e))) == {}
+    # assert variables(e).intersection(variables(standardize_variables(e))) == {}
     assert is_variable(standardize_variables(expr('x')))
 
 

--- a/tests/test_mdp.py
+++ b/tests/test_mdp.py
@@ -1,25 +1,27 @@
-import pytest
 from mdp import *  # noqa
 
 
 def test_value_iteration():
-    assert value_iteration(sequential_decision_environment, .01) == {(3, 2): 1.0, (3, 1): -1.0,
-                                        (3, 0): 0.12958868267972745, (0, 1): 0.39810203830605462,
-                                        (0, 2): 0.50928545646220924, (1, 0): 0.25348746162470537,
-                                        (0, 0): 0.29543540628363629, (1, 2): 0.64958064617168676,
-                                        (2, 0): 0.34461306281476806, (2, 1): 0.48643676237737926,
-                                        (2, 2): 0.79536093684710951}
+    assert value_iteration(sequential_decision_environment, .01) == {
+        (3, 2): 1.0, (3, 1): -1.0,
+        (3, 0): 0.12958868267972745, (0, 1): 0.39810203830605462,
+        (0, 2): 0.50928545646220924, (1, 0): 0.25348746162470537,
+        (0, 0): 0.29543540628363629, (1, 2): 0.64958064617168676,
+        (2, 0): 0.34461306281476806, (2, 1): 0.48643676237737926,
+        (2, 2): 0.79536093684710951}
 
 
 def test_policy_iteration():
-    assert policy_iteration(sequential_decision_environment) == {(0, 0): (0, 1),  (0, 1): (0, 1), (0, 2): (1, 0),
-                                            (1, 0): (1, 0),                  (1, 2): (1, 0),
-                                            (2, 0): (0, 1),  (2, 1): (0, 1), (2, 2): (1, 0),
-                                            (3, 0): (-1, 0), (3, 1): None,   (3, 2): None}
+    assert policy_iteration(sequential_decision_environment) == {
+        (0, 0): (0, 1), (0, 1): (0, 1), (0, 2): (1, 0),
+        (1, 0): (1, 0), (1, 2): (1, 0), (2, 0): (0, 1),
+        (2, 1): (0, 1), (2, 2): (1, 0), (3, 0): (-1, 0),
+        (3, 1): None, (3, 2): None}
 
 
 def test_best_policy():
-    pi = best_policy(sequential_decision_environment, value_iteration(sequential_decision_environment, .01))
+    pi = best_policy(sequential_decision_environment,
+                     value_iteration(sequential_decision_environment, .01))
     assert sequential_decision_environment.to_arrows(pi) == [['>', '>', '>', '.'],
-                                        ['^', None, '^', '.'],
-                                        ['^', '>', '^', '<']]
+                                                             ['^', None, '^', '.'],
+                                                             ['^', '>', '^', '<']]

--- a/tests/test_nlp.py
+++ b/tests/test_nlp.py
@@ -1,11 +1,12 @@
 import pytest
 import nlp
-from nlp import loadPageHTML, stripRawHTML, determineInlinks, findOutlinks, onlyWikipediaURLS
+from nlp import loadPageHTML, stripRawHTML, findOutlinks, onlyWikipediaURLS
 from nlp import expand_pages, relevant_pages, normalize, ConvergenceDetector, getInlinks
-from nlp import getOutlinks, Page, HITS
+from nlp import getOutlinks, Page
 from nlp import Rules, Lexicon
 # Clumsy imports because we want to access certain nlp.py globals explicitly, because
 # they are accessed by function's within nlp.py
+
 
 def test_rules():
     assert Rules(A="B C | D E") == {'A': [['B', 'C'], ['D', 'E']]}
@@ -27,18 +28,18 @@ testHTML = """Keyword String 1: A man is a male human.
             href="/wiki/TestLiving" href="/wiki/TestMan" >"""
 testHTML2 = "Nothing"
 
-pA = Page("A", 1, 6, ["B","C","E"],["D"])
-pB = Page("B", 2, 5, ["E"],["A","C","D"])
-pC = Page("C", 3, 4, ["B","E"],["A","D"])
-pD = Page("D", 4, 3, ["A","B","C","E"],[])
-pE = Page("E", 5, 2, [],["A","B","C","D","F"])
-pF = Page("F", 6, 1, ["E"],[])
-pageDict = {pA.address:pA,pB.address:pB,pC.address:pC,
-            pD.address:pD,pE.address:pE,pF.address:pF}
+pA = Page("A", 1, 6, ["B", "C", "E"], ["D"])
+pB = Page("B", 2, 5, ["E"], ["A", "C", "D"])
+pC = Page("C", 3, 4, ["B", "E"], ["A", "D"])
+pD = Page("D", 4, 3, ["A", "B", "C", "E"], [])
+pE = Page("E", 5, 2, [], ["A", "B", "C", "D", "F"])
+pF = Page("F", 6, 1, ["E"], [])
+pageDict = {pA.address: pA, pB.address: pB, pC.address: pC,
+            pD.address: pD, pE.address: pE, pF.address: pF}
 nlp.pagesIndex = pageDict
-nlp.pagesContent ={pA.address:testHTML,pB.address:testHTML2,
-              pC.address:testHTML,pD.address:testHTML2,
-              pE.address:testHTML,pF.address:testHTML2}
+nlp.pagesContent ={pA.address: testHTML, pB.address: testHTML2,
+                   pC.address: testHTML, pD.address: testHTML2,
+                   pE.address: testHTML, pF.address: testHTML2}
 
 # This test takes a long time (> 60 secs)
 # def test_loadPageHTML():
@@ -50,6 +51,7 @@ nlp.pagesContent ={pA.address:testHTML,pB.address:testHTML2,
 #     assert all(x in loadedPages for x in fullURLs)
 #     assert all(loadedPages.get(key,"") != "" for key in addresses)
 
+
 def test_stripRawHTML():
     addr = "https://en.wikipedia.org/wiki/Ethics"
     aPage = loadPageHTML([addr])
@@ -57,9 +59,11 @@ def test_stripRawHTML():
     strippedHTML = stripRawHTML(someHTML)
     assert "<head>" not in strippedHTML and "</head>" not in strippedHTML
 
+
 def test_determineInlinks():
     # TODO
     assert True
+
 
 def test_findOutlinks_wiki():
     testPage = pageDict[pA.address]
@@ -70,35 +74,39 @@ def test_findOutlinks_wiki():
 # ______________________________________________________________________________
 # HITS Helper Functions
 
+
 def test_expand_pages():
     pages = {k: pageDict[k] for k in ('F')}
-    pagesTwo = {k: pageDict[k] for k in ('A','E')}
+    pagesTwo = {k: pageDict[k] for k in ('A', 'E')}
     expanded_pages = expand_pages(pages)
-    assert all(x in expanded_pages for x in ['F','E'])
-    assert all(x not in expanded_pages for x in ['A','B','C','D'])
+    assert all(x in expanded_pages for x in ['F', 'E'])
+    assert all(x not in expanded_pages for x in ['A', 'B', 'C', 'D'])
     expanded_pages = expand_pages(pagesTwo)
     print(expanded_pages)
-    assert all(x in expanded_pages for x in ['A','B','C','D','E','F'])
+    assert all(x in expanded_pages for x in ['A', 'B', 'C', 'D', 'E', 'F'])
+
 
 def test_relevant_pages():
     pages = relevant_pages("male")
-    assert all((x in pages.keys()) for x in ['A','C','E'])
-    assert all((x not in pages) for x in ['B','D','F'])
+    assert all((x in pages.keys()) for x in ['A', 'C', 'E'])
+    assert all((x not in pages) for x in ['B', 'D', 'F'])
+
 
 def test_normalize():
-    normalize( pageDict )
-    print(page.hub for addr,page in nlp.pagesIndex.items())
-    expected_hub = [1/91,2/91,3/91,4/91,5/91,6/91] # Works only for sample data above
+    normalize(pageDict)
+    print(page.hub for addr, page in nlp.pagesIndex.items())
+    expected_hub = [1/91, 2/91, 3/91, 4/91, 5/91, 6/91]  # Works only for sample data above
     expected_auth = list(reversed(expected_hub))
     assert len(expected_hub) == len(expected_auth) == len(nlp.pagesIndex)
-    assert expected_hub == [page.hub for addr,page in sorted(nlp.pagesIndex.items())]
-    assert expected_auth == [page.authority for addr,page in sorted(nlp.pagesIndex.items())]
+    assert expected_hub == [page.hub for addr, page in sorted(nlp.pagesIndex.items())]
+    assert expected_auth == [page.authority for addr, page in sorted(nlp.pagesIndex.items())]
+
 
 def test_detectConvergence():
     # run detectConvergence once to initialise history
     convergence = ConvergenceDetector()
     convergence()
-    assert convergence() # values haven't changed so should return True
+    assert convergence()  # values haven't changed so should return True
     # make tiny increase/decrease to all values
     for _, page in nlp.pagesIndex.items():
         page.hub += 0.0003
@@ -111,17 +119,21 @@ def test_detectConvergence():
     # retest function with values. Should now return false
     assert not convergence()
 
+
 def test_getInlinks():
     inlnks = getInlinks(pageDict['A'])
     assert sorted([page.address for page in inlnks]) == pageDict['A'].inlinks
+
 
 def test_getOutlinks():
     outlnks = getOutlinks(pageDict['A'])
     assert sorted([page.address for page in outlnks]) == pageDict['A'].outlinks
 
+
 def test_HITS():
     # TODO
-    assert True # leave for now
+    assert True  # leave for now
+
 
 if __name__ == '__main__':
     pytest.main()

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -1,14 +1,12 @@
-from planning import *
+from planning import *  # noqa
 from utils import expr
 from logic import FolKB
 
 
 def test_action():
-    precond = [[expr("P(x)"), expr("Q(y, z)")]
-               ,[expr("Q(x)")]]
-    effect = [[expr("Q(x)")]
-              , [expr("P(x)")]]
-    a=Action(expr("A(x,y,z)"),precond, effect)
+    precond = [[expr("P(x)"), expr("Q(y, z)")], [expr("Q(x)")]]
+    effect = [[expr("Q(x)")], [expr("P(x)")]]
+    a=Action(expr("A(x,y,z)"), precond, effect)
     args = [expr("A"), expr("B"), expr("C")]
     assert a.substitute(expr("P(x, z, y)"), args) == expr("P(A, C, B)")
     test_kb = FolKB([expr("P(A)"), expr("Q(B, C)"), expr("R(D)")])
@@ -34,7 +32,8 @@ def test_air_cargo():
         p.act(action)
 
     assert p.goal_test()
-    
+
+
 def test_spare_tire():
     p = spare_tire()
     assert p.goal_test() is False
@@ -44,8 +43,9 @@ def test_spare_tire():
 
     for action in solution:
         p.act(action)
-        
+
     assert p.goal_test()
+
 
 def test_three_block_tower():
     p = three_block_tower()
@@ -56,8 +56,9 @@ def test_three_block_tower():
 
     for action in solution:
         p.act(action)
-        
+
     assert p.goal_test()
+
 
 def test_have_cake_and_eat_cake_too():
     p = have_cake_and_eat_cake_too()
@@ -69,6 +70,7 @@ def test_have_cake_and_eat_cake_too():
         p.act(action)
 
     assert p.goal_test()
+
 
 def test_graph_call():
     pdll = spare_tire()

--- a/tests/test_probability.py
+++ b/tests/test_probability.py
@@ -1,4 +1,3 @@
-import pytest
 import random
 from probability import *  # noqa
 from utils import rounder
@@ -125,11 +124,13 @@ def test_forward_backward():
 
     umbrella_evidence = [T, T, F, T, T]
     assert (rounder(forward_backward(umbrellaHMM, umbrella_evidence, umbrella_prior)) ==
-            [[0.6469, 0.3531], [0.8673, 0.1327], [0.8204, 0.1796], [0.3075, 0.6925], [0.8204, 0.1796], [0.8673, 0.1327]])
+            [[0.6469, 0.3531], [0.8673, 0.1327], [0.8204, 0.1796], [0.3075, 0.6925],
+             [0.8204, 0.1796], [0.8673, 0.1327]])
 
     umbrella_evidence = [T, F, T, F, T]
-    assert rounder(forward_backward(umbrellaHMM, umbrella_evidence, umbrella_prior)) == [[0.5871, 0.4129],
-                 [0.7177, 0.2823], [0.2324, 0.7676], [0.6072, 0.3928], [0.2324, 0.7676], [0.7177, 0.2823]]
+    assert rounder(forward_backward(umbrellaHMM, umbrella_evidence, umbrella_prior)) == [
+            [0.5871, 0.4129], [0.7177, 0.2823], [0.2324, 0.7676], [0.6072, 0.3928],
+            [0.2324, 0.7676], [0.7177, 0.2823]]
 
 
 def test_fixed_lag_smoothing():
@@ -141,7 +142,8 @@ def test_fixed_lag_smoothing():
     umbrellaHMM = HiddenMarkovModel(umbrella_transition, umbrella_sensor)
 
     d = 2
-    assert rounder(fixed_lag_smoothing(e_t, umbrellaHMM, d, umbrella_evidence, t)) == [0.1111, 0.8889]
+    assert rounder(fixed_lag_smoothing(e_t, umbrellaHMM, d,
+                                       umbrella_evidence, t)) == [0.1111, 0.8889]
     d = 5
     assert fixed_lag_smoothing(e_t, umbrellaHMM, d, umbrella_evidence, t) is None
 
@@ -150,13 +152,13 @@ def test_fixed_lag_smoothing():
     e_t = T
 
     d = 1
-    assert rounder(fixed_lag_smoothing(e_t, umbrellaHMM, d, umbrella_evidence, t)) == [0.9939, 0.0061]
+    assert rounder(fixed_lag_smoothing(e_t, umbrellaHMM,
+                                       d, umbrella_evidence, t)) == [0.9939, 0.0061]
 
 
 def test_particle_filtering():
     N = 10
     umbrella_evidence = T
-    umbrella_prior = [0.5, 0.5]
     umbrella_transition = [[0.7, 0.3], [0.3, 0.7]]
     umbrella_sensor = [[0.9, 0.2], [0.1, 0.8]]
     umbrellaHMM = HiddenMarkovModel(umbrella_transition, umbrella_sensor)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -8,7 +8,8 @@ LRTA_problem = OnlineSearchProblem('State_3', 'State_5', one_dim_state_space)
 
 
 def test_breadth_first_tree_search():
-    assert breadth_first_tree_search(romania_problem).solution() == ['Sibiu', 'Fagaras', 'Bucharest']
+    assert breadth_first_tree_search(
+        romania_problem).solution() == ['Sibiu', 'Fagaras', 'Bucharest']
 
 
 def test_breadth_first_search():
@@ -16,7 +17,8 @@ def test_breadth_first_search():
 
 
 def test_uniform_cost_search():
-    assert uniform_cost_search(romania_problem).solution() == ['Sibiu', 'Rimnicu', 'Pitesti', 'Bucharest']
+    assert uniform_cost_search(
+        romania_problem).solution() == ['Sibiu', 'Rimnicu', 'Pitesti', 'Bucharest']
 
 
 def test_depth_first_graph_search():
@@ -25,7 +27,8 @@ def test_depth_first_graph_search():
 
 
 def test_iterative_deepening_search():
-    assert iterative_deepening_search(romania_problem).solution() == ['Sibiu', 'Fagaras', 'Bucharest']
+    assert iterative_deepening_search(
+        romania_problem).solution() == ['Sibiu', 'Fagaras', 'Bucharest']
 
 
 def test_depth_limited_search():
@@ -41,7 +44,8 @@ def test_astar_search():
 
 
 def test_recursive_best_first_search():
-    assert recursive_best_first_search(romania_problem).solution() == ['Sibiu', 'Rimnicu', 'Pitesti', 'Bucharest']
+    assert recursive_best_first_search(
+        romania_problem).solution() == ['Sibiu', 'Rimnicu', 'Pitesti', 'Bucharest']
 
 
 def test_BoggleFinder():
@@ -62,7 +66,7 @@ def test_and_or_graph_search():
             return True
         if len(plan) is not 2:
             return False
-        predicate = lambda x : run_plan(x, problem, plan[1][x])
+        predicate = lambda x: run_plan(x, problem, plan[1][x])
         return all(predicate(r) for r in problem.result(state, plan[0]))
     plan = and_or_graph_search(vacumm_world)
     assert run_plan('State_1', vacumm_world, plan)
@@ -81,6 +85,7 @@ def test_LRTAStarAgent():
 
     my_agent = LRTAStarAgent(LRTA_problem)
     assert my_agent('State_5') is None
+
 
 # TODO: for .ipynb:
 """

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -201,7 +201,7 @@ def test_bigrams():
 
 >>> P3.samples(20)
 'flatland by edwin a abbott 1884 to the wake of a certificate from nature herself proving the equal sided triangle'
-"""
+"""  # noqa
 
 if __name__ == '__main__':
     pytest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -97,7 +97,8 @@ def test_scalar_vector_product():
 
 
 def test_scalar_matrix_product():
-    assert rounder(scalar_matrix_product(-5, [[1, 2], [3, 4], [0, 6]])) == [[-5, -10], [-15, -20], [0, -30]]
+    assert rounder(scalar_matrix_product(-5, [[1, 2], [3, 4], [0, 6]])) == [[-5, -10], [-15, -20],
+                                                                            [0, -30]]
     assert rounder(scalar_matrix_product(0.2, [[1, 2], [2, 3]])) == [[0.2, 0.4], [0.4, 0.6]]
 
 
@@ -167,7 +168,7 @@ def test_Expr():
 def test_expr():
     P, Q, x, y, z, GP = symbols('P, Q, x, y, z, GP')
     assert (expr(y + 2 * x)
-            == expr('y + 2 * x') 
+            == expr('y + 2 * x')
             == Expr('+', y, Expr('*', 2, x)))
     assert expr('P & Q ==> P') == Expr('==>', P & Q, P)
     assert expr('P & Q <=> Q & P') == Expr('<=>', (P & Q), (Q & P))
@@ -175,6 +176,7 @@ def test_expr():
     # x is grandparent of z if x is parent of y and y is parent of z:
     assert (expr('GP(x, z) <== P(x, y) & P(y, z)')
             == Expr('<==', GP(x, z), P(x, y) & P(y, z)))
+
 
 if __name__ == '__main__':
     pytest.main()


### PR DESCRIPTION
This MR adds a flake8 config file on the project root dir, with the same restrictions as the ones specified in the .travis.yml file. However, I have also added another warning to be excluded, which is the following one:

F405: name may be undefined, or defined from star imports: module

Since most of the tests are using the star import. However, if that is not a good idea, I can fix that as well.

There are some flake8 erros on test_csp.py, but when #299 gets accepted, they will no longer exist.