### PR TITLE
Fix __call__ command for Graph class

### DIFF
--- a/planning.py
+++ b/planning.py
@@ -405,8 +405,8 @@ class Graph:
         self.levels = [Level(pdll.kb, negkb)]
         self.objects = set(arg for clause in pdll.kb.clauses + negkb.clauses for arg in clause.args)
 
-    def __call__():
-        expand_graph()
+    def __call__(self):
+        self.expand_graph()
 
     def expand_graph(self):
         last_level = self.levels[-1]

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -69,3 +69,13 @@ def test_have_cake_and_eat_cake_too():
         p.act(action)
 
     assert p.goal_test()
+
+def test_graph_call():
+    pdll = spare_tire()
+    negkb = FolKB([expr('At(Flat, Trunk)')])
+    graph = Graph(pdll, negkb)
+
+    levels_size = len(graph.levels)
+    graph()
+
+    assert levels_size == len(graph.levels) - 1


### PR DESCRIPTION
This MR fixes a problem on the planning Graph class when the __call__ method is used. There is also a simple test to verify now that the method is working fine.