### PR TITLE
Added DataSet Functions

### DIFF
--- a/learning.py
+++ b/learning.py
@@ -152,6 +152,14 @@ class DataSet:
         return [attr_i if i in self.inputs else None
                 for i, attr_i in enumerate(example)]
 
+    def classes_to_numbers(self,classes=None):
+        """Converts class names to numbers."""
+        if not classes:
+            # If classes were not given, extract them from values
+            classes = sorted(self.values[self.target])
+        for item in self.examples:
+            item[self.target] = classes.index(item[self.target])
+
     def __repr__(self):
         return '<DataSet({}): {:d} examples, {:d} attributes>'.format(
             self.name, len(self.examples), len(self.attrs))

--- a/learning.py
+++ b/learning.py
@@ -159,6 +159,10 @@ class DataSet:
             classes = sorted(self.values[self.target])
         for item in self.examples:
             item[self.target] = classes.index(item[self.target])
+            
+    def remove_examples(self,value=""):
+        """Remove examples that contain given value."""
+        self.examples = [x for x in self.examples if value not in x]
 
     def __repr__(self):
         return '<DataSet({}): {:d} examples, {:d} attributes>'.format(


### PR DESCRIPTION
I wrote two little functions for learning.py, under the DataSet class.

The first (`classes_to_numbers`) maps the dataset's classes (values under the "target" index) to numeric values. For example, if a dataset has three classes, A, B, C, after the function call, A will turn to 0, B to 1 and C to 3.

This is essential for some of the learners, like the NeuralNetLearner, which require the classes to be numeric instead of string.

The second (`remove_examples`) removes from the dataset all the examples that contain a given value.

This is useful for either removing examples with missing data or for transforming the dataset in a desired form (eg. removing classes to make the dataset binary-class, useful for learners like the perceptron).