### PR TITLE
corrected equivalence operator to <=> from ==>

### DIFF
--- a/logic.ipynb
+++ b/logic.ipynb
@@ -306,11 +306,11 @@
     "|--------------------------|----------------------|-------------------------|---|---|\n",
     "| Negation                 | &not; P      | `~P`                       | `~P` | `Expr('~', P)`\n",
     "| And                      | P &and; Q       | `P & Q`                     | `P & Q` | `Expr('&', P, Q)`\n",
-    "| Or                       | P &or; Q | `P`<tt> &#124; </tt>`Q`| `P`<tt> &#124; </tt>`Q` | `Expr('`&#124;`', P, Q)\n",
+    "| Or                       | P &or; Q | `P`<tt> &#124; </tt>`Q`| `P`<tt> &#124; </tt>`Q` | `Expr('`&#124;`', P, Q)`\n",
     "| Inequality (Xor)         | P &ne; Q     | `P ^ Q`                | `P ^ Q`  | `Expr('^', P, Q)`\n",
     "| Implication                  | P &rarr; Q    | `P` <tt>&#124;</tt>`'==>'`<tt>&#124;</tt> `Q`   | `P ==> Q` | `Expr('==>', P, Q)`\n",
     "| Reverse Implication      | Q &larr; P     | `Q` <tt>&#124;</tt>`'<=='`<tt>&#124;</tt> `P`  |`Q <== P` | `Expr('<==', Q, P)`\n",
-    "| Equivalence            | P &harr; Q   | `P` <tt>&#124;</tt>`'<=>'`<tt>&#124;</tt> `Q`   |`P ==> Q` | `Expr('==>', P, Q)`\n",
+    "| Equivalence            | P &harr; Q   | `P` <tt>&#124;</tt>`'<=>'`<tt>&#124;</tt> `Q`   |`P <=> Q` | `Expr('<=>', P, Q)`\n",
     "\n",
     "Here's an example of defining a sentence with an implication arrow:"
    ]
@@ -708,7 +708,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.1"
+   "version": "3.4.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The equivalence operator was accidentally stated as '==>' in a location. Changed it to '<=>'.