### PR TITLE
Make build break for flake8 errors on tests dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ install:
   - pip install -r requirements.txt
 
 script:
+  - flake8 tests/
   - py.test
   - python -m doctest -v *.py
 


### PR DESCRIPTION
This MR adds on .travis.yml the flake8 command to break the build if there are some flake8 warnings on the test dir. Although this should be applied to the whole project, currently, only the tests dir is not presenting flake8 warnings. 

This is related to #304 