### PR TITLE
Removed flake8 test for pytest directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ install:
   - pip install -r requirements.txt
 
 script:
-  - flake8 tests/
   - py.test
   - python -m doctest -v *.py
 


### PR DESCRIPTION
This was added in #363 .I think it is a bad idea to put styling restrictions on tests which are not read by the readers. It is also causing the build to fail on trivialities such as missing whitespaces or blank lines.