### PR TITLE
Use lru_cache decorator on memoize function

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -270,13 +270,10 @@ except ImportError:
 # Misc Functions
 
 
-# TODO: Use functools.lru_cache memoization decorator
-
-
-def memoize(fn, slot=None):
+def memoize(fn, slot=None, maxsize=32):
     """Memoize fn: make it remember the computed value for any argument list.
     If slot is specified, store result in that slot of first argument.
-    If slot is false, store results in a dictionary."""
+    If slot is false, use lru_cache for caching the values."""
     if slot:
         def memoized_fn(obj, *args):
             if hasattr(obj, slot):
@@ -286,12 +283,9 @@ def memoize(fn, slot=None):
                 setattr(obj, slot, val)
                 return val
     else:
+        @functools.lru_cache(maxsize=maxsize)
         def memoized_fn(*args):
-            if args not in memoized_fn.cache:
-                memoized_fn.cache[args] = fn(*args)
-            return memoized_fn.cache[args]
-
-        memoized_fn.cache = {}
+            return fn(*args)
 
     return memoized_fn
 


### PR DESCRIPTION
This MR use the lru_cache decorator for caching on the memoize function. 

I have kept the slot functionality, because I think it has a differente purpose than applying the lru_cache. However, if that is not the case, I can replace it with the lru_cache decorator as well.