### PR TITLE
Bug Fixes for LinearLearner

### DIFF
--- a/learning.py
+++ b/learning.py
@@ -641,10 +641,10 @@ def LinearLearner(dataset, learning_rate=0.01, epochs=100):
 
     # Add dummy
     ones = [1 for _ in range(len(examples))]
-    X_col = ones + X_col
+    X_col = [ones] + X_col
 
     # Initialize random weigts
-    w = [random.randrange(-0.5, 0.5) for _ in range(len(idx_i) + 1)]
+    w = [random.uniform(-0.5, 0.5) for _ in range(len(idx_i) + 1)]
 
     for epoch in range(epochs):
         err = []

--- a/learning.py
+++ b/learning.py
@@ -35,6 +35,7 @@ def manhattan_distance(predictions, targets):
 def mean_boolean_error(predictions, targets):
     return mean(int(p != t) for p, t in zip(predictions, targets))
 
+
 def hamming_distance(predictions, targets):
     return sum(p != t for p, t in zip(predictions, targets))
 


### PR DESCRIPTION
In learning.py, fixed bugs for the `LinearLearner` function.

* `random.randrange` returns an integer in the range. `random.uniform` returns a float.

* `ones + X_col` (where `ones` is a list of 1s) returns a bunch of 1s and then X_col. The 1s should all be in a list, so the correct code is `[ones] + X_col`.

---

EDIT: Fixed a small, unrelated, spacing issue in the distances section.