### PR TITLE
Typo: 'logic_test.py' -> 'test_logic.py' in README.md fixed (#425) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<iv align="center">
+<div align="center">
   <a href="http://aima.cs.berkeley.edu/"><img src="https://raw.githubusercontent.com/aimacode/aima-python/master/images/aima_logo.png"></a><br><br>
 </div>
 -----------------

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div align="center">
+<iv align="center">
   <a href="http://aima.cs.berkeley.edu/"><img src="https://raw.githubusercontent.com/aimacode/aima-python/master/images/aima_logo.png"></a><br><br>
 </div>
 -----------------
@@ -18,7 +18,7 @@ When complete, this project will have Python code for all the pseudocode algorit
 
 - `logic.py`: Implementations of all the pseudocode algorithms, and necessary support functions/classes/data.
 - `logic.ipynb`: A Jupyter (IPython) notebook that explains and gives examples of how to use the code.
-- `tests/logic_test.py`: A lightweight test suite, using `assert` statements, designed for use with [`py.test`](http://pytest.org/latest/), but also usable on their own.
+- `tests/test_logic.py`: A lightweight test suite, using `assert` statements, designed for use with [`py.test`](http://pytest.org/latest/), but also usable on their own.
 
 # Index of Algorithms
 


### PR DESCRIPTION
Fixed typo mentioned in #425 