### PR TITLE
Removed post-build flake8 checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
 script:
   - py.test
   - python -m doctest -v *.py
-  - flake8 .
+  - flake8 --max-line-length 100 --ignore=E121,E123,E126,E221,E222,E225,E226,E242,E701,E702,E704,E731,W503 .
 
 after_success:
   - flake8 --max-line-length 100 --ignore=E121,E123,E126,E221,E222,E225,E226,E242,E701,E702,E704,E731,W503 .

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,7 @@ install:
 script:
   - py.test
   - python -m doctest -v *.py
-  - flake8 --max-line-length 100 --ignore=E121,E123,E126,E221,E222,E225,E226,E242,E701,E702,E704,E731,W503 .
-
-after_success:
-  - flake8 --max-line-length 100 --ignore=E121,E123,E126,E221,E222,E225,E226,E242,E701,E702,E704,E731,W503 .
+  - flake8
 
 notifications:
   email: false


### PR DESCRIPTION
#399 makes flake8 compulsory for the build to pass. We no longer need to run flake8 after the build is successful.