### PR TITLE
Implementation: Tree CSP Solver

### DIFF
--- a/tests/test_csp.py
+++ b/tests/test_csp.py
@@ -290,7 +290,7 @@ def test_topological_sort():
 
 def test_tree_csp_solver():
     australia_small = MapColoringCSP(list('RB'),
-                           'NT: WA Q; NSW: Q V; T: ')
+                           'NT: WA Q; NSW: Q V')
     tcs = tree_csp_solver(australia_small)
     assert (tcs['NT'] == 'R' and tcs['WA'] == 'B' and tcs['Q'] == 'B' and tcs['NSW'] == 'R' and tcs['V'] == 'B') or \
            (tcs['NT'] == 'B' and tcs['WA'] == 'R' and tcs['Q'] == 'R' and tcs['NSW'] == 'B' and tcs['V'] == 'R')

--- a/tests/test_csp.py
+++ b/tests/test_csp.py
@@ -274,6 +274,7 @@ def test_universal_dict():
 def test_parse_neighbours():
     assert parse_neighbors('X: Y Z; Y: Z') == {'Y': ['X', 'Z'], 'X': ['Y', 'Z'], 'Z': ['X', 'Y']}
 
+
 def test_topological_sort():
     root = 'NT'
     Sort, Parents = topological_sort(australia,root)
@@ -285,6 +286,14 @@ def test_topological_sort():
     assert Parents['NSW'] == 'Q'
     assert Parents['V'] == 'NSW'
     assert Parents['WA'] == 'SA'
+
+
+def test_tree_csp_solver():
+    australia_small = MapColoringCSP(list('RB'),
+                           'NT: WA Q; NSW: Q V; T: ')
+    tcs = tree_csp_solver(australia_small)
+    assert (tcs['NT'] == 'R' and tcs['WA'] == 'B' and tcs['Q'] == 'B' and tcs['NSW'] == 'R' and tcs['V'] == 'B') or \
+           (tcs['NT'] == 'B' and tcs['WA'] == 'R' and tcs['Q'] == 'R' and tcs['NSW'] == 'B' and tcs['V'] == 'R')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Completed the implementation of `tree_csp_solver` and added tests. In detail:

* Implemented `make_arc_consistent`. For a node *n* and its parent *p*, it removes the possible values of *p* which do not have a consistent assignment with any possible value of *n*.
* Added new function, `assign`. It assigns a value to a node consistent to the assignment of the node's parent.
* Added new function, `node_domains` which converts `UniversalDict` to a built-in dictionary. This way we can play around more with the dictionaries.
* Added test for the algorithm. The test uses the example from the book (Australia with a node removed).

Note: I had to add two new lines to the algorithm for initialization purposes. If that's an issue, I can work them into the called functions, but it will be ugly.