### PR TITLE
Notebook: Grid

### DIFF
--- a/grid.ipynb
+++ b/grid.ipynb
@@ -10,8 +10,150 @@
    "source": [
     "# Grid\n",
     "\n",
-    "The functions here are used often when dealing with 2D grids (like in TicTacToe).\n",
+    "The functions here are used often when dealing with 2D grids (like in TicTacToe)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Heading\n",
     "\n",
+    "With the `turn_heading`, `turn_left` and `turn_right` functions an agent can turn around in a grid. In a 2D grid the orientations normally are:\n",
+    "\n",
+    "* North: (0,1)\n",
+    "* South: (0,-1)\n",
+    "* East: (1,0)\n",
+    "* West: (-1,0)\n",
+    "\n",
+    "In code:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "orientations = [(1, 0), (0, 1), (-1, 0), (0, -1)]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We signify a left turn with a +1 and a right turn with a -1.\n",
+    "\n",
+    "The functions `turn_left` and `turn_right` call `turn_heading`, which then turns the agent around according to the input.\n",
+    "\n",
+    "First the code for `turn_heading`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def turn_heading(heading, inc, headings=orientations):\n",
+    "    return headings[(headings.index(heading) + inc) % len(headings)]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can now use the function to turn left:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(-1, 0)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(turn_heading((0, 1), 1))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We were facing north and we turned left, so we are now facing west.\n",
+    "\n",
+    "Let's now take a look at the other two functions, which automate this process:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def turn_right(heading):\n",
+    "    return turn_heading(heading, -1)\n",
+    "\n",
+    "def turn_left(heading):\n",
+    "    return turn_heading(heading, +1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The first one turns the agent right, so it passes -1 to `turn_heading`, while the second one turns the agent left, so it passes +1.\n",
+    "\n",
+    "Let's see what happens when we are facing north and want to turn left and right:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(-1, 0)\n",
+      "(1, 0)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(turn_left((0, 1)))\n",
+    "print(turn_right((0, 1)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When we turn left from north we end up facing west, while on the other hand if we turn right we end up facing east."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Distance\n",
     "\n",
     "The function returns the Euclidean Distance between two points in the 2D space."
@@ -139,7 +281,9 @@
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -154,7 +298,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "For example:"
    ]
@@ -163,7 +310,9 @@
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -180,7 +329,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "The vector we wanted to clip was the tuple (-1, 10). The lowest allowed values were (0, 0) and the highest (9, 9). So, the result is the tuple (0,9)."
    ]


### PR DESCRIPTION
I added the `turn_heading`, `turn_left` and `turn_right` functions to the `grid.py` Notebook.

Note: I assumed that the orientations are North: (0,1), South: (0,-1), East: (1,0) and West: (-1,0).