### PR TITLE
Queues

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -651,31 +651,7 @@ class hashabledict(dict):
 # ______________________________________________________________________________
 # Queues: Stack, FIFOQueue, PriorityQueue
 
-# TODO: queue.PriorityQueue
 # TODO: Priority queues may not belong here -- see treatment in search.py
-
-
-class Queue:
-
-    """Queue is an abstract class/interface. There are three types:
-        Stack(): A Last In First Out Queue.
-        FIFOQueue(): A First In First Out Queue.
-        PriorityQueue(order, f): Queue in sorted order (default min-first).
-    Each type supports the following methods and functions:
-        q.append(item)  -- add an item to the queue
-        q.extend(items) -- equivalent to: for item in items: q.append(item)
-        q.pop()         -- return the top item from the queue
-        len(q)          -- number of items in q (also q.__len())
-        item in q       -- does q contain item?
-    Note that isinstance(Stack(), Queue) is false, because we implement stacks
-    as lists.  If Python ever gets interfaces, Queue will be an interface."""
-
-    def __init__(self):
-        raise NotImplementedError
-
-    def extend(self, items):
-        for item in items:
-            self.append(item)
 
 
 def Stack():
@@ -683,39 +659,15 @@ def Stack():
     return []
 
 
-class FIFOQueue(Queue):
+class FIFOQueue(collections.deque):
 
     """A First-In-First-Out Queue."""
-
-    def __init__(self, maxlen=None, items=[]):
-        self.queue = collections.deque(items, maxlen)
-
-    def append(self, item):
-        if not self.queue.maxlen or len(self.queue) < self.queue.maxlen:
-            self.queue.append(item)
-        else:
-            raise Exception('FIFOQueue is full')
-
-    def extend(self, items):
-        if not self.queue.maxlen or len(self.queue) + len(items) <= self.queue.maxlen:
-            self.queue.extend(items)
-        else:
-            raise Exception('FIFOQueue max length exceeded')
-
+    
     def pop(self):
-        if len(self.queue) > 0:
-            return self.queue.popleft()
-        else:
-            raise Exception('FIFOQueue is empty')
-
-    def __len__(self):
-        return len(self.queue)
-
-    def __contains__(self, item):
-        return item in self.queue
+        return super().popleft()
 
 
-class PriorityQueue(Queue):
+class PriorityQueue():
 
     """A queue in which the minimum (or maximum) element (as determined by f and
     order) is returned first. If order is min, the item with minimum f(x) is
@@ -730,14 +682,18 @@ class PriorityQueue(Queue):
     def append(self, item):
         bisect.insort(self.A, (self.f(item), item))
 
-    def __len__(self):
-        return len(self.A)
+    def extend(self, items):
+        for item in items:
+            self.A.append(item)
 
     def pop(self):
         if self.order == min:
             return self.A.pop(0)[1]
         else:
             return self.A.pop()[1]
+
+    def __len__(self):
+        return len(self.A)
 
     def __contains__(self, item):
         return any(item == pair[1] for pair in self.A)

--- a/utils.py
+++ b/utils.py
@@ -651,7 +651,31 @@ class hashabledict(dict):
 # ______________________________________________________________________________
 # Queues: Stack, FIFOQueue, PriorityQueue
 
+# TODO: queue.PriorityQueue
 # TODO: Priority queues may not belong here -- see treatment in search.py
+
+
+class Queue:
+
+    """Queue is an abstract class/interface. There are three types:
+        Stack(): A Last In First Out Queue.
+        FIFOQueue(): A First In First Out Queue.
+        PriorityQueue(order, f): Queue in sorted order (default min-first).
+    Each type supports the following methods and functions:
+        q.append(item)  -- add an item to the queue
+        q.extend(items) -- equivalent to: for item in items: q.append(item)
+        q.pop()         -- return the top item from the queue
+        len(q)          -- number of items in q (also q.__len())
+        item in q       -- does q contain item?
+    Note that isinstance(Stack(), Queue) is false, because we implement stacks
+    as lists.  If Python ever gets interfaces, Queue will be an interface."""
+
+    def __init__(self):
+        raise NotImplementedError
+
+    def extend(self, items):
+        for item in items:
+            self.append(item)
 
 
 def Stack():
@@ -659,15 +683,15 @@ def Stack():
     return []
 
 
-class FIFOQueue(collections.deque):
+class FIFOQueue(collections.deque, Queue):
 
     """A First-In-First-Out Queue."""
-    
+
     def pop(self):
         return super().popleft()
 
 
-class PriorityQueue():
+class PriorityQueue(Queue):
 
     """A queue in which the minimum (or maximum) element (as determined by f and
     order) is returned first. If order is min, the item with minimum f(x) is
@@ -682,18 +706,14 @@ class PriorityQueue():
     def append(self, item):
         bisect.insort(self.A, (self.f(item), item))
 
-    def extend(self, items):
-        for item in items:
-            self.A.append(item)
+    def __len__(self):
+        return len(self.A)
 
     def pop(self):
         if self.order == min:
             return self.A.pop(0)[1]
         else:
             return self.A.pop()[1]
-
-    def __len__(self):
-        return len(self.A)
 
     def __contains__(self, item):
         return any(item == pair[1] for pair in self.A)

--- a/utils.py
+++ b/utils.py
@@ -683,9 +683,18 @@ def Stack():
     return []
 
 
-class FIFOQueue(collections.deque, Queue):
+class FIFOQueue(Queue, collections.deque):
 
     """A First-In-First-Out Queue."""
+
+    def __init__(self, maxlen=None, items=[]):
+        self.queue = collections.deque(items, maxlen)
+
+    def append(self, item):
+        return super().append(item)
+
+    def extend(self, items):
+        return super().extend(items)
 
     def pop(self):
         return super().popleft()


### PR DESCRIPTION
Note that this is an "experimental" PR. I made some changes according to #515 which are open to feedback, since I'm not entirely sure of the use of the classes and why things were built this way in the first place.

* I removed the abstract class `Queue`. Unless it plays a role in the pseudocode (or I'm missing something), I think it should be removed.

* Subclassed all the utilities in `FIFOQueue` from `collections.deque`, except `pop` since in `deque` it pops the rightmost element while we want to pop the leftmost one.

* Added `extend` to `PriorityQueue`, a function it was inheriting from `Queue`.

I would like some feedback on this, since I'm not entirely sure this is what was asked.