### PR TITLE
Text: Text Models

### DIFF
--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -9,9 +9,9 @@ from utils import isclose, open_data
 def test_text_models():
     flatland = open_data("EN-text/flatland.txt").read()
     wordseq = words(flatland)
-    P1 = UnigramTextModel(wordseq)
-    P2 = NgramTextModel(2, wordseq)
-    P3 = NgramTextModel(3, wordseq)
+    P1 = UnigramWordModel(wordseq)
+    P2 = NgramWordModel(2, wordseq)
+    P3 = NgramWordModel(3, wordseq)
 
     # The most frequent entries in each model
     assert P1.top(10) == [(2081, 'the'), (1479, 'of'), (1021, 'and'),
@@ -50,14 +50,14 @@ def test_text_models():
     test_string = 'unigram'
     wordseq = words(test_string)
 
-    P1 = UnigramTextModel(wordseq)
+    P1 = UnigramWordModel(wordseq)
 
     assert P1.dictionary == {('unigram'): 1}
 
     test_string = 'bigram text'
     wordseq = words(test_string)
 
-    P2 = NgramTextModel(2, wordseq)
+    P2 = NgramWordModel(2, wordseq)
 
     assert (P2.dictionary == {('', 'bigram'): 1, ('bigram', 'text'): 1} or
             P2.dictionary == {('bigram', 'text'): 1, ('', 'bigram'): 1})
@@ -66,7 +66,7 @@ def test_text_models():
     test_string = 'test trigram text'
     wordseq = words(test_string)
 
-    P3 = NgramTextModel(3, wordseq)
+    P3 = NgramWordModel(3, wordseq)
 
     assert ('', '', 'test') in P3.dictionary
     assert ('', 'test', 'trigram') in P3.dictionary
@@ -75,13 +75,14 @@ def test_text_models():
 
 
 def test_char_models():
-    test_string = 'unigram'
+    test_string = 'test unigram'
     wordseq = words(test_string)
-    P1 = NgramCharModel(1, wordseq)
+    P1 = UnigramCharModel(wordseq)
 
-    assert len(P1.dictionary) == len(test_string)
-    for char in test_string:
-        assert tuple(char) in P1.dictionary
+    expected_unigrams = {'n': 1, 's': 1, 'e': 1, 'i': 1, 'm': 1, 'g': 1, 'r': 1, 'a': 1, 't': 2, 'u': 1}
+    assert len(P1.dictionary) == len(expected_unigrams)
+    for char in test_string.replace(' ', ''):
+        assert char in P1.dictionary
 
     test_string = 'a b c'
     wordseq = words(test_string)
@@ -143,7 +144,7 @@ def test_char_models():
 def test_viterbi_segmentation():
     flatland = open_data("EN-text/flatland.txt").read()
     wordseq = words(flatland)
-    P = UnigramTextModel(wordseq)
+    P = UnigramWordModel(wordseq)
     text = "itiseasytoreadwordswithoutspaces"
 
     s, p = viterbi_segment(text, P)

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -40,7 +40,6 @@ def test_text_models():
     assert isclose(P2['of', 'the'], 0.0108, rel_tol=0.01)
 
     assert isclose(P3['', '', 'but'], 0.0, rel_tol=0.001)
-    assert isclose(P3['', '', 'but'], 0.0, rel_tol=0.001)
     assert isclose(P3['so', 'as', 'to'], 0.000323, rel_tol=0.001)
 
     assert P2.cond_prob.get(('went',)) is None

--- a/text.ipynb
+++ b/text.ipynb
@@ -2,11 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "# Text\n",
     "\n",
@@ -17,9 +13,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -29,18 +23,12 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## Contents\n",
     "\n",
     "* Text Models\n",
     "* Viterbi Text Segmentation\n",
-    "    * Overview\n",
-    "    * Implementation\n",
-    "    * Example\n",
     "* Decoders\n",
     "    * Introduction\n",
     "    * Shift Decoder\n",
@@ -49,30 +37,32 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## Text Models\n",
     "\n",
-    "Before we start performing text processing algorithms, we will need to build some word models. Those models serve as a look-up table for word probabilities. In the text module we have implemented two such models, which inherit from the `CountingProbDist` from `learning.py`. `UnigramTextModel` and `NgramTextModel`. We supply them with a text file and they show the frequency of the different words.\n",
+    "Before we start analyzing text processing algorithms, we will need to build some language models. Those models serve as a look-up table for character or word probabilities (depending on the type of model). These models can give us the probabilities of words or character sequences appearing in text. Take as example \"the\". Text models can give us the probability of \"the\", *P(\"the\")*, either as a word or as a sequence of characters (\"t\" followed by \"h\" followed by \"e\"). The first representation is called \"word model\" and deals with words as distinct objects, while the second is a \"character model\" and deals with sequences of characters as objects. Note that we can specify the number of words or the length of the char sequences to better suit our needs. So, given that number of words equals 2, we have probabilities in the form *P(word1, word2)*. For example, *P(\"of\", \"the\")*. For char models, we do the same but for chars.\n",
     "\n",
-    "The main difference between the two models is that the first returns the probability of one single word (eg. the probability of the word 'the' appearing), while the second one can show us the probability of a *sequence* of words (eg. the probability of the sequence 'of the' appearing).\n",
+    "We call the word model *N-Gram Word Model* (from the Greek \"gram\", the root of \"write\", or the word for \"letter\") and the char model *N-Gram Character Model*. In the special case where *N* is 1, we call the models *Unigram Word Model* and *Unigram Character Model* respectively.\n",
     "\n",
-    "Also, both functions can generate random words and sequences respectively, random according to the model.\n",
+    "In the `text` module we implement the two models (both their unigram and n-gram variants) by inheriting from the `CountingProbDist` from `learning.py`. Note that `CountingProbDist` does not return the actual probability of each object, but the number of times it appears in our test data.\n",
     "\n",
-    "Below we build the two models. The text file we will use to build them is the *Flatland*, by Edwin A. Abbott. We will load it from [here](https://github.com/aimacode/aima-data/blob/a21fc108f52ad551344e947b0eb97df82f8d2b2b/EN-text/flatland.txt)."
+    "For word models we have `UnigramWordModel` and `NgramWordModel`. We supply them with a text file and they show the frequency of the different words. We have `UnigramCharModel` and `NgramCharModel` for the character models.\n",
+    "\n",
+    "Below we build our models. The text file we will use to build them is *Flatland*, by Edwin A. Abbott. We will load it from [here](https://github.com/aimacode/aima-data/blob/a21fc108f52ad551344e947b0eb97df82f8d2b2b/EN-text/flatland.txt)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First the word models:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -87,8 +77,8 @@
     "flatland = open_data(\"EN-text/flatland.txt\").read()\n",
     "wordseq = words(flatland)\n",
     "\n",
-    "P1 = UnigramTextModel(wordseq)\n",
-    "P2 = NgramTextModel(2, wordseq)\n",
+    "P1 = UnigramWordModel(wordseq)\n",
+    "P2 = NgramWordModel(2, wordseq)\n",
     "\n",
     "print(P1.top(5))\n",
     "print(P2.top(5))"
@@ -96,20 +86,48 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
-    "We see that the most used word in *Flatland* is 'the', with 2081 occurences, while the most used sequence is 'of the' with 368 occurences."
+    "We see that the most used word in *Flatland* is 'the', with 2081 occurences, while the most used sequence is 'of the' with 368 occurences.\n",
+    "\n",
+    "And now the two character models:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[(19208, 'e'), (13965, 't'), (12069, 'o'), (11702, 'a'), (11440, 'i')]\n",
+      "[(5364, (' ', 't')), (4573, ('t', 'h')), (4063, (' ', 'a')), (3654, ('h', 'e')), (2967, (' ', 'i'))]\n"
+     ]
+    }
+   ],
+   "source": [
+    "flatland = open_data(\"EN-text/flatland.txt\").read()\n",
+    "wordseq = words(flatland)\n",
+    "\n",
+    "P1 = UnigramCharModel(wordseq)\n",
+    "P2 = NgramCharModel(2, wordseq)\n",
+    "\n",
+    "print(P1.top(5))\n",
+    "print(P2.top(5))"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
+   "source": [
+    "The most common letter is 'e', appearing more than 19000 times, and the most common sequence is \"\\_t\". That is, a space followed by a 't'. Note that even though we do not count spaces for word models or unigram character models, we do count them for n-gram char models."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Viterbi Text Segmentation\n",
     "\n",
@@ -122,10 +140,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Implementation"
    ]
@@ -133,11 +148,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%psource viterbi_segment"
@@ -145,10 +156,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "The function takes as input a string and a text model, and returns the most probable sequence of words, together with the probability of that sequence.\n",
     "\n",
@@ -157,10 +165,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Example\n",
     "\n",
@@ -170,11 +175,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -198,20 +199,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "The algorithm correctly retrieved the words from the string. It also gave us the probability of this sequence, which is small, but still the most probable segmentation of the string."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## Decoders\n",
     "\n",
@@ -229,11 +224,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -251,10 +242,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "#### Decoding a Caesar cipher\n",
     "\n",
@@ -264,11 +252,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -284,10 +268,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "We use `CountingProbDist` to get the probability distribution of bigrams. In the latin alphabet consists of only only `26` letters. This limits the total number of possible substitutions to `26`. We reverse the shift encoding for a given `n` and check how probable it is using the bigram distribution. We try all `26` values of `n`, i.e. from `n = 0` to `n = 26` and use the value of `n` which gives the most probable plaintext."
    ]
@@ -295,11 +276,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%psource ShiftDecoder"
@@ -307,10 +284,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "#### Example\n",
     "\n",
@@ -320,11 +294,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -343,11 +313,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -395,9 +361,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -440,9 +404,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.5.2+"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }


### PR DESCRIPTION
* Renamed the word models from `TextModel` to `WordModel`, since in the book they are referred to as word models and text models is the more general model.

* Add unigram char model. Since we have a unigram model for words, I think it is best to have a unigram char model as well.

* Updated tests accordingly.

* Updated the section *Text Models* in the notebook.