### PR TITLE
Pseudocode In Notebooks

### DIFF
--- a/knowledge.ipynb
+++ b/knowledge.ipynb
@@ -19,7 +19,9 @@
    },
    "outputs": [],
    "source": [
-    "from knowledge import *"
+    "from knowledge import *\n",
+    "\n",
+    "from notebook import pseudocode"
    ]
   },
   {
@@ -70,7 +72,7 @@
     "collapsed": true
    },
    "source": [
-    "## [CURRENT-BEST LEARNING](https://github.com/aimacode/aima-pseudocode/blob/master/md/Current-Best-Learning.md)\n",
+    "## CURRENT-BEST LEARNING\n",
     "\n",
     "### Overview\n",
     "\n",
@@ -83,6 +85,54 @@
     "* False Negative: We **generalize** the hypothesis, either by removing a conjunction or a disjunction, or by adding a disjunction.\n",
     "\n",
     "When specializing and generalizing, we should take care to not create inconsistencies with previous examples. To avoid that caveat, backtracking is needed. Thankfully, there is not just one specialization or generalization, so we have a lot to choose from. We will go through all the specialization/generalizations and we will refine our hypothesis as the first specialization/generalization consistent with all the examples seen up to that point."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Pseudocode"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "### AIMA3e\n",
+       "__function__ Current-Best-Learning(_examples_, _h_) __returns__ a hypothesis or fail  \n",
+       "&emsp;__if__ _examples_ is empty __then__  \n",
+       "&emsp;&emsp;&emsp;__return__ _h_  \n",
+       "&emsp;_e_ &larr; First(_examples_)  \n",
+       "&emsp;__if__ _e_ is consistent with _h_ __then__  \n",
+       "&emsp;&emsp;&emsp;__return__ Current-Best-Learning(Rest(_examples_), _h_)  \n",
+       "&emsp;__else if__ _e_ is a false positive for _h_ __then__  \n",
+       "&emsp;&emsp;&emsp;__for each__ _h'_ __in__ specializations of _h_ consistent with _examples_ seen so far __do__  \n",
+       "&emsp;&emsp;&emsp;&emsp;&emsp;_h''_ &larr; Current-Best-Learning(Rest(_examples_), _h'_)  \n",
+       "&emsp;&emsp;&emsp;&emsp;&emsp;__if__ _h''_ &ne; _fail_ __then return__ _h''_  \n",
+       "&emsp;__else if__ _e_ is a false negative for _h_ __then__  \n",
+       "&emsp;&emsp;&emsp;__for each__ _h'_ __in__ generalizations of _h_ consistent with _examples_ seen so far __do__  \n",
+       "&emsp;&emsp;&emsp;&emsp;&emsp;_h''_ &larr; Current-Best-Learning(Rest(_examples_), _h'_)  \n",
+       "&emsp;&emsp;&emsp;&emsp;&emsp;__if__ _h''_ &ne; _fail_ __then return__ _h''_  \n",
+       "&emsp;__return__ _fail_  \n",
+       "\n",
+       "---\n",
+       "__Figure ??__ The current-best-hypothesis learning algorithm. It searches for a consistent hypothesis that fits all the examples and backtracks when no consistent specialization/generalization can be found. To start the algorithm, any hypothesis can be passed in; it will be specialized or generalized as needed."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pseudocode('Current-Best-Learning')"
    ]
   },
   {
@@ -432,13 +482,57 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## [VERSION-SPACE LEARNING](https://github.com/aimacode/aima-pseudocode/blob/master/md/Version-Space-Learning.md)\n",
+    "## VERSION-SPACE LEARNING\n",
     "\n",
     "### Overview\n",
     "\n",
     "**Version-Space Learning** is a general method of learning in logic based domains. We generate the set of all the possible hypotheses in the domain and then we iteratively remove hypotheses inconsistent with the examples. The set of remaining hypotheses is called **version space**. Because hypotheses are being removed until we end up with a set of hypotheses consistent with all the examples, the algorithm is sometimes called **candidate elimination** algorithm.\n",
     "\n",
     "After we update the set on an example, all the hypotheses in the set are consistent with that example. So, when all the examples have been parsed, all the remaining hypotheses in the set are consistent with all the examples. That means we can pick hypotheses at random and we will always get a valid hypothesis."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Pseudocode"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "### AIMA3e\n",
+       "__function__ Version-Space-Learning(_examples_) __returns__ a version space  \n",
+       "&emsp;__local variables__: _V_, the version space: the set of all hypotheses  \n",
+       "\n",
+       "&emsp;_V_ &larr; the set of all hypotheses  \n",
+       "&emsp;__for each__ example _e_ in _examples_ __do__  \n",
+       "&emsp;&emsp;&emsp;__if__ _V_ is not empty __then__ _V_ &larr; Version-Space-Update(_V_, _e_)  \n",
+       "&emsp;__return__ _V_  \n",
+       "\n",
+       "---\n",
+       "__function__ Version-Space-Update(_V_, _e_) __returns__ an updated version space  \n",
+       "&emsp;_V_ &larr; \\{_h_ &isin; _V_ : _h_ is consistent with _e_\\}  \n",
+       "\n",
+       "---\n",
+       "__Figure ??__ The version space learning algorithm. It finds a subset of _V_ that is consistent with all the _examples_."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pseudocode('Version-Space-Learning')"
    ]
   },
   {

--- a/knowledge.ipynb
+++ b/knowledge.ipynb
@@ -21,7 +21,7 @@
    "source": [
     "from knowledge import *\n",
     "\n",
-    "from notebook import pseudocode"
+    "from notebook import pseudocode, psource"
    ]
   },
   {
@@ -145,40 +145,16 @@
     "\n",
     "We have functions to calculate the list of all specializations/generalizations, to check if an example is consistent/false positive/false negative with a hypothesis. We also have an auxiliary function to add a disjunction (or operation) to a hypothesis, and two other functions to check consistency of all (or just the negative) examples.\n",
     "\n",
-    "You can read the source by running the cells below:"
+    "You can read the source by running the cell below:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
-    "%psource current_best_learning"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "%psource specializations"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "%psource generalizations"
+    "psource(current_best_learning, specializations, generalizations)"
    ]
   },
   {
@@ -552,68 +528,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
-    "%psource version_space_learning"
+    "psource(version_space_learning, version_space_update)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
-    "%psource version_space_update"
+    "psource(all_hypotheses, values_table)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
-    "%psource all_hypotheses"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "%psource values_table"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "%psource build_attr_combinations"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "%psource build_h_combinations"
+    "psource(build_attr_combinations, build_h_combinations)"
    ]
   },
   {

--- a/notebook.py
+++ b/notebook.py
@@ -1,3 +1,5 @@
+from inspect import getsource
+
 from utils import argmax, argmin
 from games import TicTacToe, alphabeta_player, random_player, Fig52Extended, infinity
 from logic import parse_definite_clause, standardize_variables, unify, subst
@@ -15,14 +17,8 @@ import array
 #______________________________________________________________________________
 
 
-def psource(*functions):
-    """Print the source code for the given function(s)."""
-    import inspect
-
-    print('\n\n'.join(inspect.getsource(fn) for fn in functions))
-
-
 def pseudocode(algorithm):
+    """Print the pseudocode for the given algorithm."""
     from urllib.request import urlopen
     from IPython.display import Markdown
 
@@ -32,6 +28,21 @@ def pseudocode(algorithm):
     md = md.split('\n', 1)[-1].strip()
     md = '#' + md
     return Markdown(md)
+
+
+def psource(*functions):
+    """Print the source code for the given function(s)."""
+    source_code = '\n\n'.join(getsource(fn) for fn in functions)
+    try:
+        from pygments.formatters import HtmlFormatter
+        from pygments.lexers import PythonLexer
+        from pygments import highlight
+
+        display(HTML(highlight(source_code, PythonLexer(), HtmlFormatter(full=True))))
+
+    except ImportError:
+        print(source_code)
+
 
 # ______________________________________________________________________________
 

--- a/notebook.py
+++ b/notebook.py
@@ -2,7 +2,7 @@ from utils import argmax, argmin
 from games import TicTacToe, alphabeta_player, random_player, Fig52Extended, infinity
 from logic import parse_definite_clause, standardize_variables, unify, subst
 from learning import DataSet
-from IPython.display import HTML, Markdown, display
+from IPython.display import HTML, display
 from collections import Counter
 
 import matplotlib.pyplot as plt
@@ -20,6 +20,18 @@ def psource(*functions):
     import inspect
 
     print('\n\n'.join(inspect.getsource(fn) for fn in functions))
+
+
+def pseudocode(algorithm):
+    from urllib.request import urlopen
+    from IPython.display import Markdown
+
+    url = "https://raw.githubusercontent.com/aimacode/aima-pseudocode/master/md/{}.md".format(algorithm)
+    f = urlopen(url)
+    md = f.read().decode('utf-8')
+    md = md.split('\n', 1)[-1].strip()
+    md = '#' + md
+    return Markdown(md)
 
 # ______________________________________________________________________________
 


### PR DESCRIPTION
I properly packaged pseudocode printing. The code can now be found in `notebook.py`. Also, previously I didn't like very much how we would also print the name of the algorithm (the pseudocode is already in a section titled after the algorithm, so it's a bit overboard, especially since it is formatted in the largest header), so I made a couple of adjustments to amend that.

Now we only show the appropriate parts of the pseudocode, including the version of the book.

I have made the corresponding changed to the knowledge notebook, for a sample.