### PR TITLE
Python implementation for psource (#613)

### DIFF
--- a/notebook.py
+++ b/notebook.py
@@ -1,9 +1,6 @@
 from IPython.display import HTML, display
 
 from inspect import getsource
-from pygments.formatters import HtmlFormatter
-from pygments.lexers import PythonLexer
-from pygments import highlight
 
 from utils import argmax, argmin
 from games import TicTacToe, alphabeta_player, random_player, Fig52Extended, infinity
@@ -23,7 +20,16 @@ from collections import Counter
 
 def psource(*functions):
     "Print the source code for the given function(s)."
-    display(HTML(highlight(''.join(getsource(fn) for fn in functions), PythonLexer(), HtmlFormatter(full=True))))
+    source_code = '\n\n'.join(getsource(fn) for fn in functions)
+    try:
+        from pygments.formatters import HtmlFormatter
+        from pygments.lexers import PythonLexer
+        from pygments import highlight
+                              
+        display(HTML(highlight(source_code, PythonLexer(), HtmlFormatter(full=True))))
+    
+    except ImportError:
+        print(source_code)
 
 
 # ______________________________________________________________________________

--- a/notebook.py
+++ b/notebook.py
@@ -1,4 +1,10 @@
 from IPython.display import HTML, display
+
+from inspect import getsource
+from pygments.formatters import HtmlFormatter
+from pygments.lexers import PythonLexer
+from pygments import highlight
+
 from utils import argmax, argmin
 from games import TicTacToe, alphabeta_player, random_player, Fig52Extended, infinity
 from logic import parse_definite_clause, standardize_variables, unify, subst
@@ -10,6 +16,14 @@ import os, struct
 import array
 import numpy as np
 from collections import Counter
+
+
+# ______________________________________________________________________________
+
+
+def psource(*functions):
+    "Print the source code for the given function(s)."
+    display(HTML(highlight(''.join(getsource(fn) for fn in functions), PythonLexer(), HtmlFormatter(full=True))))
 
 
 # ______________________________________________________________________________


### PR DESCRIPTION
Added the python implementation for `psource` to get the output in a cell instead of a pop-up to `notebook.py` as suggested by @MrDupin . Also added syntax highlighting to this code, with dependence upon the availability of the module `pygments`.
