### PR TITLE
FOIL

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Here is a table of algorithms, the figure, name of the algorithm in the book and
 | 19.2    | Current-Best-Learning | `current_best_learning` | [`knowledge.py`](knowledge.py) | Done |
 | 19.3    | Version-Space-Learning | `version_space_learning` | [`knowledge.py`](knowledge.py) | Done |
 | 19.8    | Minimal-Consistent-Det | `minimal_consistent_det` | [`knowledge.py`](knowledge.py) | Done |
-| 19.12   | FOIL               |          | |
+| 19.12   | FOIL               | `FOIL_container` | [`knowledge.py`](knowledge.py) | Done |
 | 21.2    | Passive-ADP-Agent  | `PassiveADPAgent` | [`rl.py`][rl] | Done |
 | 21.4    | Passive-TD-Agent   | `PassiveTDAgent` | [`rl.py`][rl] | Done |
 | 21.8    | Q-Learning-Agent   | `QLearningAgent` | [`rl.py`][rl] | Done |

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -1,4 +1,5 @@
 from knowledge import *
+from utils import expr
 import random
 
 random.seed("aima-python")
@@ -57,6 +58,135 @@ def test_minimal_consistent_det():
     assert minimal_consistent_det(conductance, {'Mass', 'Temp', 'Size'}) == {'Mass', 'Temp', 'Size'}
 
 
+def test_extend_example():
+    assert list(test_network.extend_example({x: A, y: B}, expr('Conn(x, z)'))) == [
+        {x: A, y: B, z: B}, {x: A, y: B, z: D}]
+    assert list(test_network.extend_example({x: G}, expr('Conn(x, y)'))) == [{x: G, y: I}]
+    assert list(test_network.extend_example({x: C}, expr('Conn(x, y)'))) == []
+    assert len(list(test_network.extend_example({}, expr('Conn(x, y)')))) == 10
+    assert len(list(small_family.extend_example({x: expr('Andrew')}, expr('Father(x, y)')))) == 2
+    assert len(list(small_family.extend_example({x: expr('Andrew')}, expr('Mother(x, y)')))) == 0
+    assert len(list(small_family.extend_example({x: expr('Andrew')}, expr('Female(y)')))) == 6
+
+
+def test_new_literals():
+    assert len(list(test_network.new_literals([expr('p | q'), [expr('p')]]))) == 8
+    assert len(list(test_network.new_literals([expr('p'), [expr('q'), expr('p | r')]]))) == 15
+    assert len(list(small_family.new_literals([expr('p'), []]))) == 8
+    assert len(list(small_family.new_literals([expr('p & q'), []]))) == 20
+
+
+def test_choose_literal():
+    literals = [expr('Conn(p, q)'), expr('Conn(x, z)'), expr('Conn(r, s)'), expr('Conn(t, y)')]
+    examples_pos = [{x: A, y: B}, {x: A, y: D}]
+    examples_neg = [{x: A, y: C}, {x: C, y: A}, {x: C, y: B}, {x: A, y: I}]
+    assert test_network.choose_literal(literals, [examples_pos, examples_neg]) == expr('Conn(x, z)')
+    literals = [expr('Conn(x, p)'), expr('Conn(p, x)'), expr('Conn(p, q)')]
+    examples_pos = [{x: C}, {x: F}, {x: I}]
+    examples_neg = [{x: D}, {x: A}, {x: B}, {x: G}]
+    assert test_network.choose_literal(literals, [examples_pos, examples_neg]) == expr('Conn(p, x)')
+    literals = [expr('Father(x, y)'), expr('Father(y, x)'), expr('Mother(x, y)'), expr('Mother(x, y)')]
+    examples_pos = [{x: expr('Philip')}, {x: expr('Mark')}, {x: expr('Peter')}]
+    examples_neg = [{x: expr('Elizabeth')}, {x: expr('Sarah')}]
+    assert small_family.choose_literal(literals, [examples_pos, examples_neg]) == expr('Father(x, y)')
+    literals = [expr('Father(x, y)'), expr('Father(y, x)'), expr('Male(x)')]
+    examples_pos = [{x: expr('Philip')}, {x: expr('Mark')}, {x: expr('Andrew')}]
+    examples_neg = [{x: expr('Elizabeth')}, {x: expr('Sarah')}]
+    assert small_family.choose_literal(literals, [examples_pos, examples_neg]) == expr('Male(x)')
+
+
+def test_new_clause():
+    target = expr('Open(x, y)')
+    examples_pos = [{x: B}, {x: A}, {x: G}]
+    examples_neg = [{x: C}, {x: F}, {x: I}]
+    clause = test_network.new_clause([examples_pos, examples_neg], target)[0][1]
+    assert len(clause) == 1 and clause[0].op == 'Conn' and clause[0].args[0] == x
+    target = expr('Flow(x, y)')
+    examples_pos = [{x: B}, {x: D}, {x: E}, {x: G}]
+    examples_neg = [{x: A}, {x: C}, {x: F}, {x: I}, {x: H}]
+    clause = test_network.new_clause([examples_pos, examples_neg], target)[0][1]
+    assert len(clause) == 2 and \
+        ((clause[0].args[0] == x and clause[1].args[1] == x) or \
+        (clause[0].args[1] == x and clause[1].args[0] == x))
+
+
+def test_foil():
+    target = expr('Reach(x, y)')
+    examples_pos = [{x: A, y: B},
+                    {x: A, y: C},
+                    {x: A, y: D},
+                    {x: A, y: E},
+                    {x: A, y: F},
+                    {x: A, y: G},
+                    {x: A, y: I},
+                    {x: B, y: C},
+                    {x: D, y: C},
+                    {x: D, y: E},
+                    {x: D, y: F},
+                    {x: D, y: G},
+                    {x: D, y: I},
+                    {x: E, y: F},
+                    {x: E, y: G},
+                    {x: E, y: I},
+                    {x: G, y: I},
+                    {x: H, y: G},
+                    {x: H, y: I}]
+    nodes = {A, B, C, D, E, F, G, H, I}
+    examples_neg = [example for example in [{x: a, y: b} for a in nodes for b in nodes]
+                    if example not in examples_pos]
+    ## TODO: Modify FOIL to recursively check for satisfied positive examples
+#    clauses = test_network.foil([examples_pos, examples_neg], target)
+#    assert len(clauses) == 2
+    target = expr('Parent(x, y)')
+    examples_pos = [{x: expr('Elizabeth'), y: expr('Anne')},
+                    {x: expr('Elizabeth'), y: expr('Andrew')},
+                    {x: expr('Philip'), y: expr('Anne')},
+                    {x: expr('Philip'), y: expr('Andrew')},
+                    {x: expr('Anne'), y: expr('Peter')},
+                    {x: expr('Anne'), y: expr('Zara')},
+                    {x: expr('Mark'), y: expr('Peter')},
+                    {x: expr('Mark'), y: expr('Zara')},
+                    {x: expr('Andrew'), y: expr('Beatrice')},
+                    {x: expr('Andrew'), y: expr('Eugenie')},
+                    {x: expr('Sarah'), y: expr('Beatrice')},
+                    {x: expr('Sarah'), y: expr('Eugenie')}]
+    examples_neg = [{x: expr('Anne'), y: expr('Eugenie')},
+                    {x: expr('Beatrice'), y: expr('Eugenie')},
+                    {x: expr('Mark'), y: expr('Elizabeth')},
+                    {x: expr('Beatrice'), y: expr('Philip')}]
+    clauses = small_family.foil([examples_pos, examples_neg], target)
+    assert len(clauses) == 2 and \
+        ((clauses[0][1][0] == expr('Father(x, y)') and clauses[1][1][0] == expr('Mother(x, y)')) or \
+        (clauses[1][1][0] == expr('Father(x, y)') and clauses[0][1][0] == expr('Mother(x, y)')))
+    target = expr('Grandparent(x, y)')
+    examples_pos = [{x: expr('Elizabeth'), y: expr('Peter')},
+                    {x: expr('Elizabeth'), y: expr('Zara')},
+                    {x: expr('Elizabeth'), y: expr('Beatrice')},
+                    {x: expr('Elizabeth'), y: expr('Eugenie')},
+                    {x: expr('Philip'), y: expr('Peter')},
+                    {x: expr('Philip'), y: expr('Zara')},
+                    {x: expr('Philip'), y: expr('Beatrice')},
+                    {x: expr('Philip'), y: expr('Eugenie')}]
+    examples_neg = [{x: expr('Anne'), y: expr('Eugenie')},
+                    {x: expr('Beatrice'), y: expr('Eugenie')},
+                    {x: expr('Elizabeth'), y: expr('Andrew')},
+                    {x: expr('Philip'), y: expr('Anne')},
+                    {x: expr('Philip'), y: expr('Andrew')},
+                    {x: expr('Anne'), y: expr('Peter')},
+                    {x: expr('Anne'), y: expr('Zara')},
+                    {x: expr('Mark'), y: expr('Peter')},
+                    {x: expr('Mark'), y: expr('Zara')},
+                    {x: expr('Andrew'), y: expr('Beatrice')},
+                    {x: expr('Andrew'), y: expr('Eugenie')},
+                    {x: expr('Sarah'), y: expr('Beatrice')},
+                    {x: expr('Mark'), y: expr('Elizabeth')},
+                    {x: expr('Beatrice'), y: expr('Philip')}]
+#    clauses = small_family.foil([examples_pos, examples_neg], target)
+#    assert len(clauses) == 2 and \
+#        ((clauses[0][1][0] == expr('Father(x, y)') and clauses[1][1][0] == expr('Mother(x, y)')) or \
+#        (clauses[1][1][0] == expr('Father(x, y)') and clauses[0][1][0] == expr('Mother(x, y)')))
+
+
 party = [
     {'Pizza': 'Yes', 'Soda': 'No', 'GOAL': True},
     {'Pizza': 'Yes', 'Soda': 'Yes', 'GOAL': True},
@@ -104,3 +234,51 @@ restaurant = [
     r_example('No', 'No', 'No', 'No', 'None', '$', 'No', 'No', 'Thai', '0-10', False),
     r_example('Yes', 'Yes', 'Yes', 'Yes', 'Full', '$', 'No', 'No', 'Burger', '30-60', True)
 ]
+
+"""
+A              H
+|\            /|
+| \          / |
+v  v        v  v
+B  D-->E-->G-->I
+|  /   |
+| /    |
+vv     v
+C      F
+"""
+test_network = FOIL_container([expr("Conn(A, B)"),
+                               expr("Conn(A ,D)"),
+                               expr("Conn(B, C)"),
+                               expr("Conn(D, C)"),
+                               expr("Conn(D, E)"),
+                               expr("Conn(E ,F)"),
+                               expr("Conn(E, G)"),
+                               expr("Conn(G, I)"),
+                               expr("Conn(H, G)"),
+                               expr("Conn(H, I)")])
+
+small_family = FOIL_container([expr("Mother(Anne, Peter)"),
+                               expr("Mother(Anne, Zara)"),
+                               expr("Mother(Sarah, Beatrice)"),
+                               expr("Mother(Sarah, Eugenie)"),
+                               expr("Father(Mark, Peter)"),
+                               expr("Father(Mark, Zara)"),
+                               expr("Father(Andrew, Beatrice)"),
+                               expr("Father(Andrew, Eugenie)"),
+                               expr("Father(Philip, Anne)"),
+                               expr("Father(Philip, Andrew)"),
+                               expr("Mother(Elizabeth, Anne)"),
+                               expr("Mother(Elizabeth, Andrew)"),
+                               expr("Male(Philip)"),
+                               expr("Male(Mark)"),
+                               expr("Male(Andrew)"),
+                               expr("Male(Peter)"),
+                               expr("Female(Elizabeth)"),
+                               expr("Female(Anne)"),
+                               expr("Female(Sarah)"),
+                               expr("Female(Zara)"),
+                               expr("Female(Beatrice)"),
+                               expr("Female(Eugenie)"),
+])
+
+A, B, C, D, E, F, G, H, I, x, y, z = map(expr, 'ABCDEFGHIxyz')

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -164,13 +164,28 @@ def test_tt_entails():
 
 
 def test_prop_symbols():
-    assert set(prop_symbols(expr('x & y & z | A'))) == {A}
-    assert set(prop_symbols(expr('(x & B(z)) ==> Farmer(y) | A'))) == {A, expr('Farmer(y)'), expr('B(z)')}
+    assert prop_symbols(expr('x & y & z | A')) == {A}
+    assert prop_symbols(expr('(x & B(z)) ==> Farmer(y) | A')) == {A, expr('Farmer(y)'), expr('B(z)')}
 
 
 def test_constant_symbols():
-    assert set(constant_symbols(expr('x & y & z | A'))) == {A}
-    assert set(constant_symbols(expr('(x & B(z)) & Father(John) ==> Farmer(y) | A'))) == {A, expr('John')}
+    assert constant_symbols(expr('x & y & z | A')) == {A}
+    assert constant_symbols(expr('(x & B(z)) & Father(John) ==> Farmer(y) | A')) == {A, expr('John')}
+
+
+def test_predicate_symbols():
+    assert predicate_symbols(expr('x & y & z | A')) == set()
+    assert predicate_symbols(expr('(x & B(z)) & Father(John) ==> Farmer(y) | A')) == {
+        ('B', 1),
+        ('Father', 1),
+        ('Farmer', 1)}
+    assert predicate_symbols(expr('(x & B(x, y, z)) & F(G(x, y), x) ==> P(Q(R(x, y)), x, y, z)')) == {
+        ('B', 3),
+        ('F', 2),
+        ('G', 2),
+        ('P', 4),
+        ('Q', 1),
+        ('R', 2)}
 
 
 def test_eliminate_implications():


### PR DESCRIPTION
Added a basic implementation of FOIL.
The original algo, being intended for use in Prolog, is not directly compatible with python. So I've used FolKB to store and process the knowledge. This works for easy examples like the network given in the original paper and the family tree example.
The removing of positive examples is not recursive, and this is leading to technically correct but long and overfitted clauses. Any help in fixing that would be appreciated.