### PR TITLE
Fix text.py - aima-data links

### DIFF
--- a/nlp_apps.ipynb
+++ b/nlp_apps.ipynb
@@ -49,7 +49,7 @@
     "\n",
     "P_flatland = NgramCharModel(2, wordseq)\n",
     "\n",
-    "faust = open_data(\"faust.txt\").read()\n",
+    "faust = open_data(\"GE-text/faust.txt\").read()\n",
     "wordseq = words(faust)\n",
     "\n",
     "P_faust = NgramCharModel(2, wordseq)"

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -123,7 +123,7 @@ def test_char_models():
 
 def test_samples():
     story = open_data("EN-text/flatland.txt").read()
-    story += open_data("EN-text/gutenberg.txt").read()
+    story += open_data("gutenberg.txt").read()
     wordseq = words(story)
     P1 = UnigramWordModel(wordseq)
     P2 = NgramWordModel(2, wordseq)
@@ -164,7 +164,7 @@ def test_shift_decoding():
 
 
 def test_permutation_decoder():
-    gutenberg = open_data("EN-text/gutenberg.txt").read()
+    gutenberg = open_data("gutenberg.txt").read()
     flatland = open_data("EN-text/flatland.txt").read()
 
     pd = PermutationDecoder(canonicalize(gutenberg))


### PR DESCRIPTION
Some links to aima-data are now broken, this PR fixes them, in conjunction with [this aima-data PR](https://github.com/aimacode/aima-data/pull/11).

Also, the repository link to aima-data is a bit old (branch 6ce56c0). Is it possible to update it? I don't think it will make any difference, but if it's not much trouble it might be worth it.