### PR TITLE
Update aima-data Submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "aima-data"]
 	path = aima-data
-	url = https://github.com/aimacode/aima-data.git
+	url = https://github.com/aimacode/aima-data


### PR DESCRIPTION
I updated the aima-data submodule. Now it seems to be working fine (at least it does when I clone my fork). This is what I did:

```
git clone https://github.com/MrDupin/aima-python.git

cd aima-python
git submodule deinit aima-data
git rm aima-data
git submodule add https://github.com/aimacode/aima-data aima-data

git commit
git push origin
```

From cloning to pushing. I am not familiar with git, but it seems to be working as intended. You can take a look at [my fork](https://github.com/MrDupin/aima-python) to see that the submodule-link thing links to the current version of `aima-data` (we will need to update it in the future).