### PR TITLE
Remove range(len(self.args)) in favor of enumerate

### DIFF
--- a/planning.py
+++ b/planning.py
@@ -66,7 +66,7 @@ class Action:
         """Replaces variables in expression with their respective Propositional symbol"""
         new_args = list(e.args)
         for num, x in enumerate(e.args):
-            for i in range(len(self.args)):
+            for i, _ in enumerate(self.args):
                 if self.args[i] == x:
                     new_args[num] = args[i]
         return Expr(e.op, *new_args)


### PR DESCRIPTION
Throw away the second argument returned by enumerate as we do not use it. Otherwise, name `_` arg simplify the rest of this function using the returned values rather than just indexes.