### PR TITLE
Add test for Table-Driven-Vacuum-Agent.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Here is a table of algorithms, the figure, name of the algorithm in the book and
 | 2      | Model-Based-Vacuum-Agent          | `ModelBasedVacuumAgent`       | [`agents.py`][agents]           | Done |    Included      |
 | 2.1    | Environment                       | `Environment`                 | [`agents.py`][agents]           | Done | Included |
 | 2.1    | Agent                             | `Agent`                       | [`agents.py`][agents]           | Done | Included |
-| 2.3    | Table-Driven-Vacuum-Agent         | `TableDrivenVacuumAgent`      | [`agents.py`][agents]           |      | Included         |
+| 2.3    | Table-Driven-Vacuum-Agent         | `TableDrivenVacuumAgent`      | [`agents.py`][agents]           | Done | Included         |
 | 2.7    | Table-Driven-Agent                | `TableDrivenAgent`            | [`agents.py`][agents]           |      | Included         |
 | 2.8    | Reflex-Vacuum-Agent               | `ReflexVacuumAgent`           | [`agents.py`][agents]           | Done | Included         |
 | 2.10   | Simple-Reflex-Agent               | `SimpleReflexAgent`           | [`agents.py`][agents]           |      | Included         |

--- a/agents.py
+++ b/agents.py
@@ -183,9 +183,12 @@ def TableDrivenVacuumAgent():
              ((loc_B, 'Dirty'),): 'Suck',
              ((loc_A, 'Clean'), (loc_A, 'Clean')): 'Right',
              ((loc_A, 'Clean'), (loc_A, 'Dirty')): 'Suck',
+             ((loc_A, 'Dirty'), (loc_A, 'Clean')): 'Right',
              # ...
              ((loc_A, 'Clean'), (loc_A, 'Clean'), (loc_A, 'Clean')): 'Right',
              ((loc_A, 'Clean'), (loc_A, 'Clean'), (loc_A, 'Dirty')): 'Suck',
+             # ...
+             ((loc_A, 'Dirty'), (loc_A, 'Clean'), (loc_B, 'Dirty')): 'Suck',
              # ...
              }
     return Agent(TableDrivenAgentProgram(table))

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -2,7 +2,7 @@ import random
 from agents import Direction
 from agents import Agent
 from agents import ReflexVacuumAgent, ModelBasedVacuumAgent, TrivialVacuumEnvironment, compare_agents,\
-                   RandomVacuumAgent
+                   RandomVacuumAgent, TableDrivenVacuumAgent
 
 
 random.seed("aima-python")
@@ -84,6 +84,18 @@ def test_ReflexVacuumAgent() :
 def test_ModelBasedVacuumAgent() :
     # create an object of the ModelBasedVacuumAgent
     agent = ModelBasedVacuumAgent()
+    # create an object of TrivialVacuumEnvironment
+    environment = TrivialVacuumEnvironment()
+    # add agent to the environment
+    environment.add_thing(agent)
+    # run the environment
+    environment.run()
+    # check final status of the environment
+    assert environment.status == {(1,0):'Clean' , (0,0) : 'Clean'}
+
+def test_TableDrivenVacuumAgent() :
+    # create an object of the ModelBasedVacuumAgent
+    agent = TableDrivenVacuumAgent()
     # create an object of TrivialVacuumEnvironment
     environment = TrivialVacuumEnvironment()
     # add agent to the environment


### PR DESCRIPTION
Note that this changes the percept sequence table in the code, it now slightly differs from table 2.3
in the book. The underlying problem here is that a full table can principally not be specified, so '...' is used to represent the missing table entries. While this works for the book, the code requires some additional table entries for the agent to succeed.

I can see how this approach might be considered less than optimal. If that's the case, I'm happy to discuss alternative solutions. 