### PR TITLE
Ignoring .DS_Store for macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,7 @@ target/
 # dotenv
 .env
 .idea
+
+# for macOS
+.DS_Store
+._.DS_Store


### PR DESCRIPTION
Self-explanatory. Appears to be a common problem on [SO](https://stackoverflow.com/questions/107701/how-can-i-remove-ds-store-files-from-a-git-repository).