### PR TITLE
Removed append from the list of algorithms

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,6 @@ Here is a table of algorithms, the figure, name of the algorithm in the book and
 | 9.1    | Unify                             | `unify`                       | [`logic.py`][logic]             | Done | Included |
 | 9.3    | FOL-FC-Ask                        | `fol_fc_ask`                  | [`logic.py`][logic]             | Done | Included |
 | 9.6    | FOL-BC-Ask                        | `fol_bc_ask`                  | [`logic.py`][logic]             | Done | Included |
-| 9.8    | Append                            |                               |                                 |      |          |
 | 10.1   | Air-Cargo-problem                 | `air_cargo`                   | [`planning.py`][planning]       | Done | Included |
 | 10.2   | Spare-Tire-Problem                | `spare_tire`                  | [`planning.py`][planning]       | Done | Included |
 | 10.3   | Three-Block-Tower                 | `three_block_tower`           | [`planning.py`][planning]       | Done | Included |


### PR DESCRIPTION
The `append` procedure demonstrates how the `append` function in Prolog works and it is something that we don't need to cover in aima-python, as sugested by @norvig 