### PR TITLE
Minor refactor on a variable name

### DIFF
--- a/search.py
+++ b/search.py
@@ -112,7 +112,7 @@ class Node:
         next_state = problem.result(self.state, action)
         next_node = Node(next_node, self, action,
                     problem.path_cost(self.path_cost, self.state,
-                                      action, next_node))
+                                      action, next_state))
         return next_node
     
     def solution(self):

--- a/search.py
+++ b/search.py
@@ -110,7 +110,7 @@ class Node:
     def child_node(self, problem, action):
         """[Figure 3.10]"""
         next_state = problem.result(self.state, action)
-        next_node = Node(next_node, self, action,
+        next_node = Node(next_state, self, action,
                     problem.path_cost(self.path_cost, self.state,
                                       action, next_state))
         return next_node


### PR DESCRIPTION
`child_node` method of `Node` uses the `problem.result` which returns normally a state not a node according to its docstring in `Problem`. Naming the variable `next_node` can be confusing to users when it actually refers to a resulting state.