### PR TITLE
activate pruning inside `forward_checking`

### DIFF
--- a/csp.py
+++ b/csp.py
@@ -230,6 +230,7 @@ def no_inference(csp, var, value, assignment, removals):
 
 def forward_checking(csp, var, value, assignment, removals):
     """Prune neighbor values inconsistent with var=value."""
+    csp.support_pruning()
     for B in csp.neighbors[var]:
         if B not in assignment:
             for b in csp.curr_domains[B][:]:


### PR DESCRIPTION
Otherwise `csp.curr_domains` may not be available for the loop that follows.