### PR TITLE
soled a typo in nlp.ipynb

### DIFF
--- a/nlp.ipynb
+++ b/nlp.ipynb
@@ -85,7 +85,7 @@
     "S -> aSb [0.7] | ε [0.3]\n",
     "```\n",
     "\n",
-    "Now we know it is more likely for `S` to be replaced by `aSb` than by `e`.\n",
+    "Now we know it is more likely for `S` to be replaced by `aSb` than by `ε`.\n",
     "\n",
     "An issue with *PCFGs* is how we will assign the various probabilities to the rules. We could use our knowledge as humans to assign the probabilities, but that is a laborious and prone to error task. Instead, we can *learn* the probabilities from data. Data is categorized as labeled (with correctly parsed sentences, usually called a **treebank**) or unlabeled (given only lexical and syntactic category names).\n",
     "\n",
@@ -1034,7 +1034,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.3"
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This was a small typo in nlp.ipynb. 