### PR TITLE
tf-idf added(#890)

### DIFF
--- a/nlp_apps.ipynb
+++ b/nlp_apps.ipynb
@@ -797,11 +797,215 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {
     "collapsed": true
    },
+   "source": [
+    "## Text Analysis using TF-IDF\n",
+    "Since we know that computers are great with numbers but they cannot work out with the natural language. So in-order to overcome that text can be directly converted to numbers for analyzing.One of the most common and popular technique for this is TF-IDF which stands for Term Frequency and Inverse Document Frequency. \n",
+    "\n",
+    "1. **TF(Term -Frequency):-**Gives the frequency of each word in a document. As the number of occurances of a word increases in a document its value increases for that document. Basically, if a word appears more times in a docuemnt then that word is important to that document. \n",
+    "    \n",
+    "    **TF(t) = (Number of times term t appears in a document) / (Total number of terms in the document)**\n",
+    "\n",
+    "\n",
+    "2. **IDF(Inverse Document Frequency):-** It calculates, how much a word is important for a given document. The words that occur in less documents are more important as compared to the words that occur in more number of documents. It helps to find the important words across the documents .\n",
+    "\n",
+    "    **IDF(t) = log(Total number of documents / (1+Number of documents with term t in it))**\n",
+    "    \n",
+    "    (1 is added to the base for coding purposes. It helps to deal with the cases when the term does not appears in any document)\n",
+    "\n",
+    "\n",
+    "*TF-IDF* finally gives the importance to a single word in a collection of documents by multiplying the TF of that word in that document with the  IDF of that word  across the documents.\n",
+    "\n",
+    "\n",
+    "#### Working with TF-IDF  \n",
+    "1. First of all we need a list of all the documents to work on.\n",
+    "2. Next, basic text-procesing is done over all the documents.\n",
+    "3. Now, an object is made of the class tf_idf_analyis with the list of all pre-processed text.\n",
+    "4. We can find the term-frequency of a given document using *get_term_frequency(doc)*.\n",
+    "5. The relevance of word can be calculated using *get_tf_idf_score(word,doc)* function. \n",
+    "6. Using this object we can get the *n* most important words of the document using *top(doc,n)* function.\n",
+    "7. We can see the tf-idf vector i.e. score of all the words in the document by *tf_idf_vector(doc)*.\n",
+    "8. We can also search for a query by doing pre-text-processing on the text and then passing it on *search_query(query)*.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 245,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from utils import open_data\n",
+    "from text import *\n",
+    "import re\n",
+    "import math\n",
+    "\n",
+    "document_0 = \"China has a strong economy that is growing at a rapid pace. However politically it differs greatly from the US Economy.\"\n",
+    "document_1 = \"At last, China seems serious about confronting an endemic problem: domestic violence and corruption.\"\n",
+    "document_2 = \"Japan's prime minister, Shinzo Abe, is working towards healing the economic turmoil in his own country for his view on the future of his people.\"\n",
+    "document_3 = \"Vladimir Putin is working hard to fix the economy in Russia as the Ruble has tumbled.\"\n",
+    "document_4 = \"What's the future of Abenomics? We asked Shinzo Abe for his views\"\n",
+    "document_5 = \"Obama has eased sanctions on Cuba while accelerating those against the Russian Economy, even as the Ruble's value falls almost daily.\"\n",
+    "document_6 = \"Vladimir Putin is riding a horse while hunting deer. Vladimir Putin always seems so serious about things - even riding horses. Is he crazy?\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 238,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "docs=[document_0,document_1,document_2,document_3,document_4,document_5,document_6]\n",
+    "for i in range(len(docs)):\n",
+    "    docs[i]=' '.join(words(docs[i]))\n",
+    "\n",
+    "x=tf_idf_analysis(docs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 239,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "relevance of the word \"in\" in docs[1]:-  0.0864317144890127\n",
+      "0.18906905358773213\n"
+     ]
+    }
+   ],
+   "source": [
+    "word=\"in\"\n",
+    "doc_no=1\n",
+    "print(\"relevance of the word \\\"\"+word+\"\\\" in docs[\"+str(doc_no)+\"]:- \",x.get_tf_idf_score(\"corruption\",docs[doc_no]))\n",
+    "# this also works with any other random document\n",
+    "new_doc=\"corruption in this world.\"\n",
+    "print(x.get_tf_idf_score(word,new_doc))\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 241,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'china': 0.047619047619047616, 'has': 0.047619047619047616, 'a': 0.09523809523809523, 'strong': 0.047619047619047616, 'economy': 0.09523809523809523, 'that': 0.047619047619047616, 'is': 0.047619047619047616, 'growing': 0.047619047619047616, 'at': 0.047619047619047616, 'rapid': 0.047619047619047616, 'pace': 0.047619047619047616, 'however': 0.047619047619047616, 'politically': 0.047619047619047616, 'it': 0.047619047619047616, 'differs': 0.047619047619047616, 'greatly': 0.047619047619047616, 'from': 0.047619047619047616, 'the': 0.047619047619047616, 'us': 0.047619047619047616}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# to get the normalized term frequency of all the words in the docuemnt\n",
+    "print(x.get_term_frequency(docs[0]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 242,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[('a', 0.07708019302933156),\n",
+       " ('strong', 0.05827855288121937),\n",
+       " ('that', 0.05827855288121937),\n",
+       " ('growing', 0.05827855288121937),\n",
+       " ('rapid', 0.05827855288121937),\n",
+       " ('pace', 0.05827855288121937),\n",
+       " ('however', 0.05827855288121937),\n",
+       " ('politically', 0.05827855288121937),\n",
+       " ('it', 0.05827855288121937),\n",
+       " ('differs', 0.05827855288121937)]"
+      ]
+     },
+     "execution_count": 242,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# we can also see the top 10 most important words to that document \n",
+    "x.top(0,10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 243,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'at': 0.05845751239286325,\n",
+       " 'last': 0.0864317144890127,\n",
+       " 'china': 0.05845751239286325,\n",
+       " 'seems': 0.05845751239286325,\n",
+       " 'serious': 0.05845751239286325,\n",
+       " 'about': 0.05845751239286325,\n",
+       " 'confronting': 0.0864317144890127,\n",
+       " 'an': 0.0864317144890127,\n",
+       " 'endemic': 0.0864317144890127,\n",
+       " 'problem': 0.0864317144890127,\n",
+       " 'domestic': 0.0864317144890127,\n",
+       " 'violence': 0.0864317144890127,\n",
+       " 'and': 0.0864317144890127,\n",
+       " 'corruption': 0.0864317144890127}"
+      ]
+     },
+     "execution_count": 243,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# we can get the tf-idf vector of the complete sentence  \n",
+    "x.get_tf_idf_vector(docs[1])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Query Search using TF-IDF\n",
+    "For searching a query in a list of documents, a *relevance score* for each document is calculated. This is calucated by :-\n",
+    "1. Finding the common words in the query and the document. \n",
+    "2. Then the tf-idf score of the common words in the query and the document are multiplied.\n",
+    "3. Then the cosine simmilarity is calculated b/w the query and that document by multiplying the tf-idf score of the common words and then dividing them by the magnitude of both the vectors.\n",
+    "This can be implemented using *search_query(query)* function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 244,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[(6, 0.4257678912782361), (3, 0.3325447850032575), (0, 0), (1, 0), (2, 0), (4, 0), (5, 0)]\n"
+     ]
+    }
+   ],
+   "source": [
+    "query=\"Vladimir putin\"\n",
+    "results=x.search_query(\" \".join(words(query)))\n",
+    "print(results)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": []
   }
@@ -822,7 +1026,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,

--- a/nlp_apps.ipynb
+++ b/nlp_apps.ipynb
@@ -37,10 +37,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 32,
+   "metadata": {},
    "outputs": [],
    "source": [
     "from utils import open_data\n",
@@ -68,10 +66,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 33,
+   "metadata": {},
    "outputs": [],
    "source": [
     "from learning import NaiveBayesLearner\n",
@@ -92,10 +88,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 34,
+   "metadata": {},
    "outputs": [],
    "source": [
     "def recognize(sentence, nBS, n):\n",
@@ -122,7 +116,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
     {
@@ -138,7 +132,7 @@
        "'German'"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -149,7 +143,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [
     {
@@ -165,7 +159,7 @@
        "'English'"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -176,7 +170,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [
     {
@@ -192,7 +186,7 @@
        "'German'"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -203,7 +197,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [
     {
@@ -219,7 +213,7 @@
        "'English'"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 38,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -254,10 +248,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 39,
+   "metadata": {},
    "outputs": [],
    "source": [
     "from utils import open_data\n",
@@ -285,10 +277,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 40,
+   "metadata": {},
    "outputs": [],
    "source": [
     "from learning import NaiveBayesLearner\n",
@@ -307,10 +297,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 41,
+   "metadata": {},
    "outputs": [],
    "source": [
     "def recognize(sentence, nBS):\n",
@@ -329,7 +317,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [
     {
@@ -338,7 +326,7 @@
        "'Abbott'"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 42,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -358,7 +346,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [
     {
@@ -367,7 +355,7 @@
        "'Austen'"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 43,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -402,10 +390,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 44,
+   "metadata": {},
    "outputs": [],
    "source": [
     "from utils import open_data\n",
@@ -423,7 +409,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [
     {
@@ -432,7 +418,7 @@
        "'The Project Gutenberg EBook of The Federalist Papers, by \\nAlexander Hamilton and John Jay and James Madison\\n\\nThis eBook is for the use of anyone anywhere at no cost and with\\nalmost no restrictions whatsoever.  You may copy it, give it away or\\nre-use it under the terms of the Project Gutenberg License included\\nwith this eBook or online at www.gutenberg.net\\n\\n\\nTitle: The Federalist Papers\\n\\nAuthor: Alexander Hamilton\\n        John Jay\\n        James Madison\\n\\nPosting Date: December 12, 2011 [EBook #18]'"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 45,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -450,10 +436,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 46,
+   "metadata": {},
    "outputs": [],
    "source": [
     "wordseq = words(federalist)\n",
@@ -469,7 +453,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [
     {
@@ -478,7 +462,7 @@
        "'federalist no 1 general introduction for the independent journal hamilton to the people of the state of new york after an unequivocal experience of the inefficacy of the subsisting federal government you are called upon to deliberate on a new constitution for the united states of america the subject speaks its own importance comprehending in its consequences nothing less than the existence of the union the safety and welfare of the parts of which it is composed the fate of an empire in many respects the most interesting in the world it has been frequently remarked that it seems to'"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 47,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -500,10 +484,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 48,
+   "metadata": {},
    "outputs": [],
    "source": [
     "wordseq = [w for w in wordseq if w != 'publius']"
@@ -522,7 +504,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [
     {
@@ -531,7 +513,7 @@
        "(4, 16, 52)"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 49,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -568,10 +550,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 50,
+   "metadata": {},
    "outputs": [],
    "source": [
     "hamilton = ''.join(hamilton)\n",
@@ -603,10 +583,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 51,
+   "metadata": {},
    "outputs": [],
    "source": [
     "import random\n",
@@ -687,10 +665,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 52,
+   "metadata": {},
    "outputs": [],
    "source": [
     "dist = {('Madison', 1): P_madison, ('Hamilton', 1): P_hamilton, ('Jay', 1): P_jay}\n",
@@ -707,10 +683,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 53,
+   "metadata": {},
    "outputs": [],
    "source": [
     "def recognize(sentence, nBS):\n",
@@ -726,7 +700,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 54,
    "metadata": {},
    "outputs": [
     {
@@ -737,7 +711,7 @@
       "Straightforward Naive Bayes Learner\n",
       "\n",
       "Paper No. 49: Hamilton: 0.0000 Madison: 1.0000 Jay: 0.0000\n",
-      "Paper No. 50: Hamilton: 0.0000 Madison: 1.0000 Jay: 0.0000\n",
+      "Paper No. 50: Hamilton: 0.0000 Madison: 0.0000 Jay: 1.0000\n",
       "Paper No. 51: Hamilton: 0.0000 Madison: 1.0000 Jay: 0.0000\n",
       "Paper No. 52: Hamilton: 0.0000 Madison: 1.0000 Jay: 0.0000\n",
       "Paper No. 53: Hamilton: 0.0000 Madison: 1.0000 Jay: 0.0000\n",
@@ -746,8 +720,8 @@
       "Paper No. 56: Hamilton: 0.0000 Madison: 1.0000 Jay: 0.0000\n",
       "Paper No. 57: Hamilton: 0.0000 Madison: 1.0000 Jay: 0.0000\n",
       "Paper No. 58: Hamilton: 0.0000 Madison: 1.0000 Jay: 0.0000\n",
-      "Paper No. 18: Hamilton: 0.0000 Madison: 1.0000 Jay: 0.0000\n",
-      "Paper No. 19: Hamilton: 0.0000 Madison: 1.0000 Jay: 0.0000\n",
+      "Paper No. 18: Hamilton: 0.0000 Madison: 0.0000 Jay: 1.0000\n",
+      "Paper No. 19: Hamilton: 0.0000 Madison: 0.0000 Jay: 1.0000\n",
       "Paper No. 20: Hamilton: 0.0000 Madison: 1.0000 Jay: 0.0000\n",
       "Paper No. 64: Hamilton: 1.0000 Madison: 0.0000 Jay: 0.0000\n",
       "\n",
@@ -803,38 +777,37 @@
    },
    "source": [
     "## Text Analysis using TF-IDF\n",
-    "Since we know that computers are great with numbers but they cannot work out with the natural language. So in-order to overcome that text can be directly converted to numbers for analyzing.One of the most common and popular technique for this is TF-IDF which stands for Term Frequency and Inverse Document Frequency. \n",
+    "We know that computers are great with numbers but they cannot work out with the natural language. So in order to overcome the problem, the text is converted to numbers for analysis. One of the most common and popular techniques for this is TF-IDF which stands for Term Frequency and Inverse Document Frequency. \n",
     "\n",
-    "1. **TF(Term -Frequency):-**Gives the frequency of each word in a document. As the number of occurances of a word increases in a document its value increases for that document. Basically, if a word appears more times in a docuemnt then that word is important to that document. \n",
+    "1. **TF(Term Frequency):-** Gives the frequency of each word in a document. As the number of occurrences of a word increases in a document its value increases for that document. Basically, if a word appears more times in a document then that word is important to that document.\n",
     "    \n",
     "    **TF(t) = (Number of times term t appears in a document) / (Total number of terms in the document)**\n",
     "\n",
     "\n",
-    "2. **IDF(Inverse Document Frequency):-** It calculates, how much a word is important for a given document. The words that occur in less documents are more important as compared to the words that occur in more number of documents. It helps to find the important words across the documents .\n",
+    "2. **IDF(Inverse Document Frequency):-** The Inverse Document Frequency is a measure of how much information the word provides, i.e., if it's common or rare across all documents. It calculates how much a word is important for a given set of document. The words that occur in fewer documents are more important compared to the words that occur in more documents. It helps to find the important words across the documents.\n",
     "\n",
-    "    **IDF(t) = log(Total number of documents / (1+Number of documents with term t in it))**\n",
+    "    **IDF(t) = log( (Total number of documents) / (1 + Number of documents with term t in it ))**\n",
     "    \n",
-    "    (1 is added to the base for coding purposes. It helps to deal with the cases when the term does not appears in any document)\n",
+    "    (1 is added to the base for coding purposes. It helps to deal with the cases when the term does not appear in any document. The fraction term in the log would have a denominator of zero. So in order to prevent division by zero 1 is added in the denominator.)\n",
     "\n",
     "\n",
-    "*TF-IDF* finally gives the importance to a single word in a collection of documents by multiplying the TF of that word in that document with the  IDF of that word  across the documents.\n",
+    "*TF-IDF* finally gives the importance of a single word in a collection of documents by multiplying the TF of that word in that document with the IDF of that word across the documents.\n",
     "\n",
     "\n",
     "#### Working with TF-IDF  \n",
-    "1. First of all we need a list of all the documents to work on.\n",
-    "2. Next, basic text-procesing is done over all the documents.\n",
-    "3. Now, an object is made of the class tf_idf_analyis with the list of all pre-processed text.\n",
-    "4. We can find the term-frequency of a given document using *get_term_frequency(doc)*.\n",
-    "5. The relevance of word can be calculated using *get_tf_idf_score(word,doc)* function. \n",
-    "6. Using this object we can get the *n* most important words of the document using *top(doc,n)* function.\n",
-    "7. We can see the tf-idf vector i.e. score of all the words in the document by *tf_idf_vector(doc)*.\n",
-    "8. We can also search for a query by doing pre-text-processing on the text and then passing it on *search_query(query)*.\n",
-    "\n"
+    "1. First of all, we need a list of all the documents to work on.\n",
+    "2. Next, basic text-processing is done over all the documents.\n",
+    "3. Now, an object is made of the class `tf_idf_analyis` with the list of all pre-processed text.\n",
+    "4. We can find the term-frequency of a given document using `get_term_frequency(doc)`.\n",
+    "5. The relevance of a word can be calculated using `get_tf_idf_score(word, doc)` function. \n",
+    "6. Using this object we can get the `n` most important words of the document using `top(doc, n)` function.\n",
+    "7. We can see the TF-IDF vector 'i.e. score of all the words in the document' by `tf_idf_vector(doc)`.\n",
+    "8. We can also search for a query by doing pre-processing on the text and then passing it on `search_query(query)`.\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 245,
+   "execution_count": 55,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -854,44 +827,44 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 238,
+   "execution_count": 56,
    "metadata": {},
    "outputs": [],
    "source": [
-    "docs=[document_0,document_1,document_2,document_3,document_4,document_5,document_6]\n",
+    "docs = [document_0, document_1, document_2, document_3, document_4, document_5, document_6]\n",
     "for i in range(len(docs)):\n",
-    "    docs[i]=' '.join(words(docs[i]))\n",
+    "    docs[i] = ' '.join(words(docs[i]))\n",
     "\n",
-    "x=tf_idf_analysis(docs)"
+    "x = tf_idf_analysis(docs)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 239,
+   "execution_count": 57,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "relevance of the word \"in\" in docs[1]:-  0.0864317144890127\n",
+      "Relevance of the word \"in\" in docs[1]:-  0.0864317144890127\n",
       "0.18906905358773213\n"
      ]
     }
    ],
    "source": [
-    "word=\"in\"\n",
-    "doc_no=1\n",
-    "print(\"relevance of the word \\\"\"+word+\"\\\" in docs[\"+str(doc_no)+\"]:- \",x.get_tf_idf_score(\"corruption\",docs[doc_no]))\n",
+    "word = \"in\"\n",
+    "doc_no = 1\n",
+    "print(\"Relevance of the word \\\"\" + word + \"\\\" in docs[\" + str(doc_no) + \"]:- \", x.get_tf_idf_score(\"corruption\", docs[doc_no]))\n",
     "# this also works with any other random document\n",
-    "new_doc=\"corruption in this world.\"\n",
-    "print(x.get_tf_idf_score(word,new_doc))\n",
+    "new_doc = \"corruption in this world.\"\n",
+    "print(x.get_tf_idf_score(word, new_doc))\n",
     "\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 241,
+   "execution_count": 58,
    "metadata": {},
    "outputs": [
     {
@@ -909,7 +882,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 242,
+   "execution_count": 59,
    "metadata": {},
    "outputs": [
     {
@@ -927,20 +900,22 @@
        " ('differs', 0.05827855288121937)]"
       ]
      },
-     "execution_count": 242,
+     "execution_count": 59,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# we can also see the top 10 most important words to that document \n",
-    "x.top(0,10)"
+    "x.top(0, 10)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 243,
-   "metadata": {},
+   "execution_count": 60,
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [
     {
      "data": {
@@ -961,7 +936,7 @@
        " 'corruption': 0.0864317144890127}"
       ]
      },
-     "execution_count": 243,
+     "execution_count": 60,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -976,16 +951,16 @@
    "metadata": {},
    "source": [
     "#### Query Search using TF-IDF\n",
-    "For searching a query in a list of documents, a *relevance score* for each document is calculated. This is calucated by :-\n",
+    "For searching a query in a list of documents, a *relevance score* for each document is calculated. This is calculated by:-\n",
     "1. Finding the common words in the query and the document. \n",
-    "2. Then the tf-idf score of the common words in the query and the document are multiplied.\n",
-    "3. Then the cosine simmilarity is calculated b/w the query and that document by multiplying the tf-idf score of the common words and then dividing them by the magnitude of both the vectors.\n",
-    "This can be implemented using *search_query(query)* function."
+    "2. Then the TF-IDF score of the common words in the query and the document are multiplied.\n",
+    "3. Then the cosine similarity is calculated between the query and that document by multiplying the TF-IDF score of the common words and then dividing them by the magnitude of both the vectors. \n",
+    "This can be implemented using `search_query(query)` function."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 244,
+   "execution_count": 61,
    "metadata": {},
    "outputs": [
     {
@@ -997,17 +972,10 @@
     }
    ],
    "source": [
-    "query=\"Vladimir putin\"\n",
-    "results=x.search_query(\" \".join(words(query)))\n",
+    "query = \"Vladimir putin\"\n",
+    "results = x.search_query(\" \".join(words(query)))\n",
     "print(results)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/text.py
+++ b/text.py
@@ -8,7 +8,7 @@ from utils import argmin, argmax, hashabledict
 from learning import CountingProbDist
 import search
 
-from math import log, exp
+import math
 from collections import defaultdict
 import heapq
 import re
@@ -184,8 +184,8 @@ class IRSystem:
     def score(self, word, docid):
         """Compute a score for this word on the document with this docid."""
         # There are many options; here we take a very simple approach
-        return (log(1 + self.index[word][docid]) /
-                log(1 + self.documents[docid].nwords))
+        return (math.log(1 + self.index[word][docid]) /
+                math.log(1 + self.documents[docid].nwords))
 
     def total_score(self, words, docid):
         """Compute the sum of the scores of these words on the document with this docid."""
@@ -390,10 +390,10 @@ class PermutationDecoder:
 
         # add small positive value to prevent computing log(0)
         # TODO: Modify the values to make score more accurate
-        logP = (sum(log(self.Pwords[word] + 1e-20) for word in words(text)) +
-                sum(log(self.P1[c] + 1e-5) for c in text) +
-                sum(log(self.P2[b] + 1e-10) for b in bigrams(text)))
-        return -exp(logP)
+        logP = (sum(math.log(self.Pwords[word] + 1e-20) for word in words(text)) +
+                sum(math.log(self.P1[c] + 1e-5) for c in text) +
+                sum(math.log(self.P2[b] + 1e-10) for b in bigrams(text)))
+        return -math.exp(logP)
 
 
 class PermutationDecoderProblem(search.Problem):
@@ -418,93 +418,118 @@ class PermutationDecoderProblem(search.Problem):
     def goal_test(self, state):
         """We're done when all letters in search domain are assigned."""
         return len(state) >= len(self.decoder.chardomain)
+
+
 #-----------------------------TF-IDF--------------------------------------
+
+
 class tf_idf_analysis:
-    '''a class to perform tf-idf analysis on a given set of documents and also search a query'''
-#     class variabels(their type)= values contained in the variable
-#     docs(list)=contains all the documents
-#     terms_tf_idf_score(list of dict)=tf-idf-score of all the documents with all words
-#     doc_tf(list of dict)=a list containting the tf of each word in each document
-#     terms_df(dict of list)= gives the df of ach term
-    def __init__(self,docs):
-        '''input: list of all documents'''
-        self.docs=docs
-        self.tf_idf_score=self.make_tf_idf()
+    """A class to perform TF-IDF analysis on a given set of documents and search a query from the given set of documents.
+
+        variabels(type) = Values contained in the variable.
+
+        docs(list of strings) = Contains a list of all the documents as a string.
+        terms_tf_idf_score(list of dict) = TF-IDF-Score of all the documents with all words.
+        doc_tf(list of dict)= A list containing the Term Frequency of every word in the corresponding document.
+        terms_df(dict of list)= Gives the Document Frequency of each term.
+    """
+    
+    def __init__(self, docs):
+        """Input: A list of all documents."""
+    
+        self.docs = docs
+        self.tf_idf_score = self.make_tf_idf()
+    
     def make_tf_idf(self):
-        '''makes the tf-idf score of all the words in all the documents'''
-        terms_df={}
-        doc_tf=[]
-        counter=0
+        """Makes the TF-IDF score of all the words in all the documents."""
+    
+        terms_df, doc_tf, counter, terms_tf_idf_score = {}, [], 0, []
+        
         for i in self.docs:
-            counter+=1
-            tf=self.get_term_frequency(i)
+            counter += 1
+            tf = self.get_term_frequency(i)
             doc_tf.append(tf)
+            
             for j in tf.items():
-                if(terms_df.get(j[0],None)==None):
-                    terms_df[j[0]]=[counter]
+                if(terms_df.get(j[0], None) == None):
+                    terms_df[j[0]] = [counter]
                 elif(i not in terms_df[j[0]]):
                     terms_df[j[0]].append(counter)
-        terms_tf_idf_score=[]
+        
         for i in doc_tf:
-            x={}
+            x = {}
             for j in i.items():
-                x[j[0]]=self.tf_mul_idf(j[1],len(terms_df.get(j[0],[])))
+                x[j[0]] = self.tf_mul_idf(j[1], len(terms_df.get(j[0], [])))
             terms_tf_idf_score.append(x)
-        self.terms_tf_idf_score=terms_tf_idf_score
-        self.doc_tf=doc_tf
-        self.terms_df=terms_df
+        
+        self.terms_tf_idf_score = terms_tf_idf_score
+        self.doc_tf = doc_tf
+        self.terms_df = terms_df
+        
         return terms_tf_idf_score
-    def tf_mul_idf(self,tf,df):
-        '''multiplies the term frequency and inter-docuemt frequency to give the correct score'''
-        return math.log(1+tf)*math.log(len(self.docs)/(1+df))
-    def get_term_frequency(self,doc):
-        '''returns a dictionary containing the frequency of each term in a given document'''
-        term_freq={}
-        total_terms=0
+    
+    def tf_mul_idf(self, tf, df):
+        """Multiplies the Term Frequency and Inter-Document Frequency to give the correct score."""
+        return math.log(1 + tf) * math.log(len(self.docs) / (1 + df))
+    
+    def get_term_frequency(self, doc):
+        """Returns a dictionary containing the frequency of each term in a given document."""
+        term_freq, total_terms={}, 0
+        
         for i in doc.split():
             total_terms+=1
-            if(term_freq.get(i,0)==0):
-                term_freq[i]=1
+            if(term_freq.get(i, 0) == 0):
+                term_freq[i] = 1
             else:
-                term_freq[i]+=1
+                term_freq[i] += 1
+
         for i,j in term_freq.items():
-            term_freq[i]=j/total_terms
+            term_freq[i] = j / total_terms
+
         return term_freq
-    def get_doc_no(self,doc):
-        '''gets the document number of a given document from the list of docuemnts given '''
-        counter=0
+
+    def get_doc_no(self, doc):
+        """Gets the document number of a given document from the list of documents given."""
+        counter = 0
         for i in self.docs:
-            if(i==doc):
+            if(i == doc):
                 return counter
-            counter+=1
-    def get_tf_idf_score(self,word,doc):
-        '''returns the tf-idf score of the document '''
-        tf=self.get_term_frequency(doc)
-        ans=self.tf_mul_idf(tf.get(word,0),len(self.terms_df.get(word,[])))
+            counter += 1
+    
+    def get_tf_idf_score(self, word, doc):
+        """Returns the TF-IDF score of the document."""
+        tf = self.get_term_frequency(doc)
+        ans = self.tf_mul_idf(tf.get(word, 0), len(self.terms_df.get(word, [])))
         return ans
-    def top(self,doc_no,n):
-        '''returns top n most important word of the given document number'''
-        x=self.terms_tf_idf_score[doc_no]
-        return sorted(x.items(),key=lambda z:z[1],reverse=True)[:n]
-    def get_tf_idf_vector(self,doc):
-        '''returns the tf-idf vector of the document'''
-        tf=self.get_term_frequency(doc)
-        vector={}
+
+    def top(self, doc_no, n):
+        """Returns top-n most important word of the given document number."""
+        x = self.terms_tf_idf_score[doc_no]
+        return sorted(x.items(), key = lambda z: z[1], reverse = True)[:n]
+    
+    def get_tf_idf_vector(self, doc):
+        """Returns the TF-IDF vector of the document."""
+        tf = self.get_term_frequency(doc)
+        vector = {}
         for i in doc.split():
-            vector[i]=self.tf_mul_idf(tf.get(i,0),len(self.terms_df.get(i,[])))
+            vector[i] = self.tf_mul_idf(tf.get(i,0), len(self.terms_df.get(i, [])))
+        
         return vector
-    def search_query(self,query):
-        '''returns the sorted list of all the relevant docuemnts along with their relevance scores'''
-        queryvec=self.get_tf_idf_vector(query)
-        doc_score={}
-        query_mag=math.sqrt(sum([j[1]**2 for j in queryvec.items()]))
+    
+    def search_query(self, query):
+        """Returns the sorted list of all the relevant docuemnts along with their relevance scores."""
+        queryvec = self.get_tf_idf_vector(query)
+        doc_score = {}
+        query_mag = math.sqrt(sum([j[1]**2 for j in queryvec.items()]))
+        
         for i in range(len(self.docs)):
-            common_words=[j for j in query.split() if j in self.docs[i].split()]
-            if(len(common_words)==0):
-                doc_score[i]=0
+            common_words = [j for j in query.split() if j in self.docs[i].split()]
+            if(len(common_words) == 0):
+                doc_score[i] = 0
             else:
-                dot_product=sum([queryvec[j]*self.terms_tf_idf_score[i][j] for j in common_words])
-                doc_mag=math.sqrt(sum([j[1]**2 for j in self.terms_tf_idf_score[i].items()]))
-                doc_score[i]=dot_product/(query_mag*doc_mag)
-        sorted_doc_score=sorted(doc_score.items(),key=lambda x:x[1],reverse=True)
+                dot_product = sum([queryvec[j] * self.terms_tf_idf_score[i][j] for j in common_words])
+                doc_mag = math.sqrt(sum([j[1]**2 for j in self.terms_tf_idf_score[i].items()]))
+                doc_score[i] = dot_product / (query_mag * doc_mag)
+        
+        sorted_doc_score = sorted(doc_score.items(), key = lambda x: x[1], reverse= True)
         return sorted_doc_score

--- a/text.py
+++ b/text.py
@@ -8,7 +8,7 @@ from utils import argmin, argmax, hashabledict
 from learning import CountingProbDist
 import search
 
-import math
+from math import log,exp
 from collections import defaultdict
 import heapq
 import re
@@ -184,8 +184,8 @@ class IRSystem:
     def score(self, word, docid):
         """Compute a score for this word on the document with this docid."""
         # There are many options; here we take a very simple approach
-        return (math.log(1 + self.index[word][docid]) /
-                math.log(1 + self.documents[docid].nwords))
+        return (log(1 + self.index[word][docid]) /
+                log(1 + self.documents[docid].nwords))
 
     def total_score(self, words, docid):
         """Compute the sum of the scores of these words on the document with this docid."""
@@ -390,10 +390,10 @@ class PermutationDecoder:
 
         # add small positive value to prevent computing log(0)
         # TODO: Modify the values to make score more accurate
-        logP = (sum(math.log(self.Pwords[word] + 1e-20) for word in words(text)) +
-                sum(math.log(self.P1[c] + 1e-5) for c in text) +
-                sum(math.log(self.P2[b] + 1e-10) for b in bigrams(text)))
-        return -math.exp(logP)
+        logP = (sum(log(self.Pwords[word] + 1e-20) for word in words(text)) +
+                sum(log(self.P1[c] + 1e-5) for c in text) +
+                sum(log(self.P2[b] + 1e-10) for b in bigrams(text)))
+        return -exp(logP)
 
 
 class PermutationDecoderProblem(search.Problem):
@@ -426,12 +426,12 @@ class PermutationDecoderProblem(search.Problem):
 class tf_idf_analysis:
     """A class to perform TF-IDF analysis on a given set of documents and search a query from the given set of documents.
 
-        variabels(type) = Values contained in the variable.
+        variables(type) = Values contained in the variable.
 
         docs(list of strings) = Contains a list of all the documents as a string.
         terms_tf_idf_score(list of dict) = TF-IDF-Score of all the documents with all words.
-        doc_tf(list of dict)= A list containing the Term Frequency of every word in the corresponding document.
-        terms_df(dict of list)= Gives the Document Frequency of each term.
+        doc_tf(list of dict) = A list containing the Term Frequency of every word in the corresponding document.
+        terms_df(dict of list) = Gives the Document Frequency of each term.
     """
     
     def __init__(self, docs):
@@ -470,7 +470,7 @@ class tf_idf_analysis:
     
     def tf_mul_idf(self, tf, df):
         """Multiplies the Term Frequency and Inter-Document Frequency to give the correct score."""
-        return math.log(1 + tf) * math.log(len(self.docs) / (1 + df))
+        return log(1 + tf) * log(len(self.docs) / (1 + df))
     
     def get_term_frequency(self, doc):
         """Returns a dictionary containing the frequency of each term in a given document."""

--- a/text.py
+++ b/text.py
@@ -418,3 +418,93 @@ class PermutationDecoderProblem(search.Problem):
     def goal_test(self, state):
         """We're done when all letters in search domain are assigned."""
         return len(state) >= len(self.decoder.chardomain)
+#-----------------------------TF-IDF--------------------------------------
+class tf_idf_analysis:
+    '''a class to perform tf-idf analysis on a given set of documents and also search a query'''
+#     class variabels(their type)= values contained in the variable
+#     docs(list)=contains all the documents
+#     terms_tf_idf_score(list of dict)=tf-idf-score of all the documents with all words
+#     doc_tf(list of dict)=a list containting the tf of each word in each document
+#     terms_df(dict of list)= gives the df of ach term
+    def __init__(self,docs):
+        '''input: list of all documents'''
+        self.docs=docs
+        self.tf_idf_score=self.make_tf_idf()
+    def make_tf_idf(self):
+        '''makes the tf-idf score of all the words in all the documents'''
+        terms_df={}
+        doc_tf=[]
+        counter=0
+        for i in self.docs:
+            counter+=1
+            tf=self.get_term_frequency(i)
+            doc_tf.append(tf)
+            for j in tf.items():
+                if(terms_df.get(j[0],None)==None):
+                    terms_df[j[0]]=[counter]
+                elif(i not in terms_df[j[0]]):
+                    terms_df[j[0]].append(counter)
+        terms_tf_idf_score=[]
+        for i in doc_tf:
+            x={}
+            for j in i.items():
+                x[j[0]]=self.tf_mul_idf(j[1],len(terms_df.get(j[0],[])))
+            terms_tf_idf_score.append(x)
+        self.terms_tf_idf_score=terms_tf_idf_score
+        self.doc_tf=doc_tf
+        self.terms_df=terms_df
+        return terms_tf_idf_score
+    def tf_mul_idf(self,tf,df):
+        '''multiplies the term frequency and inter-docuemt frequency to give the correct score'''
+        return math.log(1+tf)*math.log(len(self.docs)/(1+df))
+    def get_term_frequency(self,doc):
+        '''returns a dictionary containing the frequency of each term in a given document'''
+        term_freq={}
+        total_terms=0
+        for i in doc.split():
+            total_terms+=1
+            if(term_freq.get(i,0)==0):
+                term_freq[i]=1
+            else:
+                term_freq[i]+=1
+        for i,j in term_freq.items():
+            term_freq[i]=j/total_terms
+        return term_freq
+    def get_doc_no(self,doc):
+        '''gets the document number of a given document from the list of docuemnts given '''
+        counter=0
+        for i in self.docs:
+            if(i==doc):
+                return counter
+            counter+=1
+    def get_tf_idf_score(self,word,doc):
+        '''returns the tf-idf score of the document '''
+        tf=self.get_term_frequency(doc)
+        ans=self.tf_mul_idf(tf.get(word,0),len(self.terms_df.get(word,[])))
+        return ans
+    def top(self,doc_no,n):
+        '''returns top n most important word of the given document number'''
+        x=self.terms_tf_idf_score[doc_no]
+        return sorted(x.items(),key=lambda z:z[1],reverse=True)[:n]
+    def get_tf_idf_vector(self,doc):
+        '''returns the tf-idf vector of the document'''
+        tf=self.get_term_frequency(doc)
+        vector={}
+        for i in doc.split():
+            vector[i]=self.tf_mul_idf(tf.get(i,0),len(self.terms_df.get(i,[])))
+        return vector
+    def search_query(self,query):
+        '''returns the sorted list of all the relevant docuemnts along with their relevance scores'''
+        queryvec=self.get_tf_idf_vector(query)
+        doc_score={}
+        query_mag=math.sqrt(sum([j[1]**2 for j in queryvec.items()]))
+        for i in range(len(self.docs)):
+            common_words=[j for j in query.split() if j in self.docs[i].split()]
+            if(len(common_words)==0):
+                doc_score[i]=0
+            else:
+                dot_product=sum([queryvec[j]*self.terms_tf_idf_score[i][j] for j in common_words])
+                doc_mag=math.sqrt(sum([j[1]**2 for j in self.terms_tf_idf_score[i].items()]))
+                doc_score[i]=dot_product/(query_mag*doc_mag)
+        sorted_doc_score=sorted(doc_score.items(),key=lambda x:x[1],reverse=True)
+        return sorted_doc_score


### PR DESCRIPTION
As mentioned in Issue #890, `TF-IDF` has been added as a separate section with implementation in `text.py` and implementation details and explanation in `nlp_apps.ipynb`.
The following things have been added:-
1. Making a `TF-IDF` from a given set of documents.
2. Getting the relevance of a word in a document.
3. Getting top n most important words in that document. 
4. Query Searching and Ranking using `TF-IDF`