### PR TITLE
Fixed a typo in README (pl_fc_entails)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Here is a table of algorithms, the figure, name of the algorithm in the book and
 | 7.10   | TT-Entails                        | `tt_entails`                  | [`logic.py`][logic]             | Done | Included |
 | 7.12   | PL-Resolution                     | `pl_resolution`               | [`logic.py`][logic]             | Done | Included |
 | 7.14   | Convert to CNF                    | `to_cnf`                      | [`logic.py`][logic]             | Done | Included |
-| 7.15   | PL-FC-Entails?                    | `pl_fc_resolution`            | [`logic.py`][logic]             | Done | Included |
+| 7.15   | PL-FC-Entails?                    | `pl_fc_entails`               | [`logic.py`][logic]             | Done | Included |
 | 7.17   | DPLL-Satisfiable?                 | `dpll_satisfiable`            | [`logic.py`][logic]             | Done | Included |
 | 7.18   | WalkSAT                           | `WalkSAT`                     | [`logic.py`][logic]             | Done | Included |
 | 7.20   | Hybrid-Wumpus-Agent               | `HybridWumpusAgent`           |                                 |      |          |


### PR DESCRIPTION
Hello, this will be my first (tiny) contribution. I noticed that `pl_fc_resolution` mentioned in README does not even exist in the project, the correct name should be `pl_fc_entails`.