### PR TITLE
Install dependencies from `requirements.txt` missing in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ To download the repository:
 
 `git clone https://github.com/aimacode/aima-python.git`
 
+Then you need to install the basic dependencies to run the project in your system (although they are very less):
+
+`pip install -r requirements.txt`
+
 You also need to fetch the datasets from the [`aima-data`](https://github.com/aimacode/aima-data) repository:
 
 ```

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To download the repository:
 
 `git clone https://github.com/aimacode/aima-python.git`
 
-Then you need to install the basic dependencies to run the project in your system (although they are very less):
+Then you need to install the basic dependencies to run the project in your system:
 
 `pip install -r requirements.txt`
 


### PR DESCRIPTION
An important step was missing in the `README.md`, i.e. the instructions to install the dependencies from `requirements.txt` in the system.

