### PR TITLE
The function truncated_svd() should not return negative singular values.

### DIFF
--- a/learning.py
+++ b/learning.py
@@ -460,9 +460,15 @@ def truncated_svd(X, num_val=2, max_iter=1000):
 
         projected_X = matrix_multiplication(A, [[x] for x in X])
         projected_X = [x[0] for x in projected_X]
-        eivals.append(norm(projected_X, 1)/norm(X, 1))
-        eivec_m.append(X[:m])
-        eivec_n.append(X[m:])
+        new_eigenvalue = norm(projected_X, 1)/norm(X, 1)
+        ev_m = X[:m]
+        ev_n = X[m:]
+        if new_eigenvalue < 0:
+            new_eigenvalue = -new_eigenvalue
+            ev_m = [-ev_m_i for ev_m_i in ev_m]
+        eivals.append(new_eigenvalue)
+        eivec_m.append(ev_m)
+        eivec_n.append(ev_n)
     return (eivec_m, eivec_n, eivals)
 
 # ______________________________________________________________________________

--- a/tests/test_learning.py
+++ b/tests/test_learning.py
@@ -143,28 +143,28 @@ def test_truncated_svd():
     test_mat = [[17, 0],
                 [0, 11]]
     _, _, eival = truncated_svd(test_mat)
-    assert isclose(abs(eival[0]), 17)
-    assert isclose(abs(eival[1]), 11)
+    assert isclose(eival[0], 17)
+    assert isclose(eival[1], 11)
 
     test_mat = [[17, 0],
                 [0, -34]]
     _, _, eival = truncated_svd(test_mat)
-    assert isclose(abs(eival[0]), 34)
-    assert isclose(abs(eival[1]), 17)
+    assert isclose(eival[0], 34)
+    assert isclose(eival[1], 17)
 
     test_mat = [[1, 0, 0, 0, 2],
                 [0, 0, 3, 0, 0],
                 [0, 0, 0, 0, 0],
                 [0, 2, 0, 0, 0]]
     _, _, eival = truncated_svd(test_mat)
-    assert isclose(abs(eival[0]), 3)
-    assert isclose(abs(eival[1]), 5**0.5)
+    assert isclose(eival[0], 3)
+    assert isclose(eival[1], 5**0.5)
 
     test_mat = [[3, 2, 2],
                 [2, 3, -2]]
     _, _, eival = truncated_svd(test_mat)
-    assert isclose(abs(eival[0]), 5)
-    assert isclose(abs(eival[1]), 3)
+    assert isclose(eival[0], 5)
+    assert isclose(eival[1], 3)
 
 
 def test_decision_tree_learner():


### PR DESCRIPTION
@Chipe1 @norvig Singular values by definition are non-negative, but currently truncated_svd() returns negative singular values at times.

This pull request modifies truncated_svd() and its respective truncated_svd() tests to always return non-negative real singular values.