### PR TITLE
Update the link to search4e.ipynb

### DIFF
--- a/index.ipynb
+++ b/index.ipynb
@@ -18,7 +18,7 @@
     "\n",
     "3. [**Search**](./search.ipynb)\n",
     "\n",
-    "4. [**Search - 4th edition**](./search-4e.ipynb)\n",
+    "4. [**Search - 4th edition**](./search4e.ipynb)\n",
     "\n",
     "4. [**Games**](./games.ipynb)\n",
     "\n",


### PR DESCRIPTION
The "search-4e.ipynb" in line 21 is a typo for search4e.ipynb. File search-4e.ipynb does not exist. It will show 404 error.