### PR TITLE
fixing the names SimpleRNNLearner and AutoencoderLearner

### DIFF
--- a/notebooks/chapter19/RNN.ipynb
+++ b/notebooks/chapter19/RNN.ipynb
@@ -53,7 +53,31 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Using TensorFlow backend.\n"
+      "Using TensorFlow backend.\n",
+      "/usr/local/lib/python3.6/dist-packages/tensorflow/python/framework/dtypes.py:516: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.\n",
+      "  _np_qint8 = np.dtype([(\"qint8\", np.int8, 1)])\n",
+      "/usr/local/lib/python3.6/dist-packages/tensorflow/python/framework/dtypes.py:517: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.\n",
+      "  _np_quint8 = np.dtype([(\"quint8\", np.uint8, 1)])\n",
+      "/usr/local/lib/python3.6/dist-packages/tensorflow/python/framework/dtypes.py:518: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.\n",
+      "  _np_qint16 = np.dtype([(\"qint16\", np.int16, 1)])\n",
+      "/usr/local/lib/python3.6/dist-packages/tensorflow/python/framework/dtypes.py:519: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.\n",
+      "  _np_quint16 = np.dtype([(\"quint16\", np.uint16, 1)])\n",
+      "/usr/local/lib/python3.6/dist-packages/tensorflow/python/framework/dtypes.py:520: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.\n",
+      "  _np_qint32 = np.dtype([(\"qint32\", np.int32, 1)])\n",
+      "/usr/local/lib/python3.6/dist-packages/tensorflow/python/framework/dtypes.py:525: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.\n",
+      "  np_resource = np.dtype([(\"resource\", np.ubyte, 1)])\n",
+      "/usr/local/lib/python3.6/dist-packages/tensorboard/compat/tensorflow_stub/dtypes.py:541: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.\n",
+      "  _np_qint8 = np.dtype([(\"qint8\", np.int8, 1)])\n",
+      "/usr/local/lib/python3.6/dist-packages/tensorboard/compat/tensorflow_stub/dtypes.py:542: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.\n",
+      "  _np_quint8 = np.dtype([(\"quint8\", np.uint8, 1)])\n",
+      "/usr/local/lib/python3.6/dist-packages/tensorboard/compat/tensorflow_stub/dtypes.py:543: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.\n",
+      "  _np_qint16 = np.dtype([(\"qint16\", np.int16, 1)])\n",
+      "/usr/local/lib/python3.6/dist-packages/tensorboard/compat/tensorflow_stub/dtypes.py:544: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.\n",
+      "  _np_quint16 = np.dtype([(\"quint16\", np.uint16, 1)])\n",
+      "/usr/local/lib/python3.6/dist-packages/tensorboard/compat/tensorflow_stub/dtypes.py:545: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.\n",
+      "  _np_qint32 = np.dtype([(\"qint32\", np.int32, 1)])\n",
+      "/usr/local/lib/python3.6/dist-packages/tensorboard/compat/tensorflow_stub/dtypes.py:550: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.\n",
+      "  np_resource = np.dtype([(\"resource\", np.ubyte, 1)])\n"
      ]
     }
    ],
@@ -158,13 +182,14 @@
        "<body>\n",
        "<h2></h2>\n",
        "\n",
-       "<div class=\"highlight\"><pre><span></span><span class=\"k\">def</span> <span class=\"nf\">simple_rnn_learner</span><span class=\"p\">(</span><span class=\"n\">train_data</span><span class=\"p\">,</span> <span class=\"n\">val_data</span><span class=\"p\">,</span> <span class=\"n\">epochs</span><span class=\"o\">=</span><span class=\"mi\">2</span><span class=\"p\">):</span>\n",
+       "<div class=\"highlight\"><pre><span></span><span class=\"k\">def</span> <span class=\"nf\">SimpleRNNLearner</span><span class=\"p\">(</span><span class=\"n\">train_data</span><span class=\"p\">,</span> <span class=\"n\">val_data</span><span class=\"p\">,</span> <span class=\"n\">epochs</span><span class=\"o\">=</span><span class=\"mi\">2</span><span class=\"p\">):</span>\n",
        "    <span class=\"sd\">&quot;&quot;&quot;</span>\n",
-       "<span class=\"sd\">    rnn example for text sentimental analysis</span>\n",
+       "<span class=\"sd\">    RNN example for text sentimental analysis.</span>\n",
        "<span class=\"sd\">    :param train_data: a tuple of (training data, targets)</span>\n",
        "<span class=\"sd\">            Training data: ndarray taking training examples, while each example is coded by embedding</span>\n",
-       "<span class=\"sd\">            Targets: ndarry taking targets of each example. Each target is mapped to an integer.</span>\n",
+       "<span class=\"sd\">            Targets: ndarray taking targets of each example. Each target is mapped to an integer.</span>\n",
        "<span class=\"sd\">    :param val_data: a tuple of (validation data, targets)</span>\n",
+       "<span class=\"sd\">    :param epochs: number of epochs</span>\n",
        "<span class=\"sd\">    :return: a keras model</span>\n",
        "<span class=\"sd\">    &quot;&quot;&quot;</span>\n",
        "\n",
@@ -199,7 +224,7 @@
     }
    ],
    "source": [
-    "psource(simple_rnn_learner)"
+    "psource(SimpleRNNLearner)"
    ]
   },
   {
@@ -220,7 +245,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -238,39 +263,51 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING: Logging before flag parsing goes to stderr.\n",
+      "W1018 11:18:25.754184 139973198665536 deprecation.py:323] From /usr/local/lib/python3.6/dist-packages/tensorflow/python/ops/nn_impl.py:180: add_dispatch_support.<locals>.wrapper (from tensorflow.python.ops.array_ops) is deprecated and will be removed in a future version.\n",
+      "Instructions for updating:\n",
+      "Use tf.where in 2.0, which has the same broadcast rule as np.where\n",
+      "W1018 11:18:26.423906 139973198665536 deprecation_wrapper.py:119] From /usr/local/lib/python3.6/dist-packages/keras/backend/tensorflow_backend.py:422: The name tf.global_variables is deprecated. Please use tf.compat.v1.global_variables instead.\n",
+      "\n"
+     ]
+    },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "Train on 24990 samples, validate on 25000 samples\n",
       "Epoch 1/10\n",
-      " - 45s - loss: 0.6877 - acc: 0.5406 - val_loss: 0.6731 - val_acc: 0.6045\n",
+      " - 62s - loss: 0.6675 - accuracy: 0.5692 - val_loss: 0.6368 - val_accuracy: 0.6248\n",
       "Epoch 2/10\n",
-      " - 52s - loss: 0.6441 - acc: 0.6241 - val_loss: 0.6258 - val_acc: 0.6300\n",
+      " - 63s - loss: 0.5553 - accuracy: 0.7174 - val_loss: 0.5038 - val_accuracy: 0.7612\n",
       "Epoch 3/10\n",
-      " - 50s - loss: 0.5275 - acc: 0.7393 - val_loss: 0.5547 - val_acc: 0.7229\n",
+      " - 64s - loss: 0.4703 - accuracy: 0.7925 - val_loss: 0.5607 - val_accuracy: 0.7427\n",
       "Epoch 4/10\n",
-      " - 50s - loss: 0.4703 - acc: 0.7908 - val_loss: 0.4851 - val_acc: 0.7740\n",
+      " - 62s - loss: 0.5701 - accuracy: 0.6976 - val_loss: 0.6186 - val_accuracy: 0.6440\n",
       "Epoch 5/10\n",
-      " - 48s - loss: 0.4021 - acc: 0.8279 - val_loss: 0.4517 - val_acc: 0.8121\n",
+      " - 67s - loss: 0.5079 - accuracy: 0.7602 - val_loss: 0.5736 - val_accuracy: 0.7152\n",
       "Epoch 6/10\n",
-      " - 55s - loss: 0.4043 - acc: 0.8269 - val_loss: 0.4532 - val_acc: 0.8042\n",
+      " - 64s - loss: 0.5645 - accuracy: 0.7066 - val_loss: 0.5814 - val_accuracy: 0.6827\n",
       "Epoch 7/10\n",
-      " - 51s - loss: 0.4242 - acc: 0.8315 - val_loss: 0.5257 - val_acc: 0.7785\n",
+      " - 65s - loss: 0.4510 - accuracy: 0.7918 - val_loss: 0.5198 - val_accuracy: 0.7439\n",
       "Epoch 8/10\n",
-      " - 58s - loss: 0.4534 - acc: 0.7964 - val_loss: 0.5347 - val_acc: 0.7323\n",
+      " - 67s - loss: 0.4458 - accuracy: 0.7985 - val_loss: 0.6681 - val_accuracy: 0.6143\n",
       "Epoch 9/10\n",
-      " - 51s - loss: 0.3821 - acc: 0.8354 - val_loss: 0.4671 - val_acc: 0.8054\n",
+      " - 66s - loss: 0.5261 - accuracy: 0.7435 - val_loss: 0.5917 - val_accuracy: 0.7105\n",
       "Epoch 10/10\n",
-      " - 56s - loss: 0.3283 - acc: 0.8691 - val_loss: 0.4523 - val_acc: 0.8067\n"
+      " - 64s - loss: 0.5762 - accuracy: 0.6814 - val_loss: 0.6450 - val_accuracy: 0.5956\n"
      ]
     }
    ],
    "source": [
-    "model = simple_rnn_learner(train, val, epochs=10)"
+    "model = SimpleRNNLearner(train, val, epochs=10)"
    ]
   },
   {
@@ -306,7 +343,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -398,18 +435,24 @@
        "<body>\n",
        "<h2></h2>\n",
        "\n",
-       "<div class=\"highlight\"><pre><span></span><span class=\"k\">def</span> <span class=\"nf\">auto_encoder_learner</span><span class=\"p\">(</span><span class=\"n\">inputs</span><span class=\"p\">,</span> <span class=\"n\">encoding_size</span><span class=\"p\">,</span> <span class=\"n\">epochs</span><span class=\"o\">=</span><span class=\"mi\">200</span><span class=\"p\">):</span>\n",
-       "    <span class=\"sd\">&quot;&quot;&quot;simple example of linear auto encoder learning producing the input itself.</span>\n",
+       "<div class=\"highlight\"><pre><span></span><span class=\"k\">def</span> <span class=\"nf\">AutoencoderLearner</span><span class=\"p\">(</span><span class=\"n\">inputs</span><span class=\"p\">,</span> <span class=\"n\">encoding_size</span><span class=\"p\">,</span> <span class=\"n\">epochs</span><span class=\"o\">=</span><span class=\"mi\">200</span><span class=\"p\">):</span>\n",
+       "    <span class=\"sd\">&quot;&quot;&quot;</span>\n",
+       "<span class=\"sd\">    Simple example of linear auto encoder learning producing the input itself.</span>\n",
        "<span class=\"sd\">    :param inputs: a batch of input data in np.ndarray type</span>\n",
-       "<span class=\"sd\">    :param encoding_size: int, the size of encoding layer&quot;&quot;&quot;</span>\n",
+       "<span class=\"sd\">    :param encoding_size: int, the size of encoding layer</span>\n",
+       "<span class=\"sd\">    :param epochs: number of epochs</span>\n",
+       "<span class=\"sd\">    :return: a keras model</span>\n",
+       "<span class=\"sd\">    &quot;&quot;&quot;</span>\n",
        "\n",
        "    <span class=\"c1\"># init data</span>\n",
        "    <span class=\"n\">input_size</span> <span class=\"o\">=</span> <span class=\"nb\">len</span><span class=\"p\">(</span><span class=\"n\">inputs</span><span class=\"p\">[</span><span class=\"mi\">0</span><span class=\"p\">])</span>\n",
        "\n",
        "    <span class=\"c1\"># init model</span>\n",
        "    <span class=\"n\">model</span> <span class=\"o\">=</span> <span class=\"n\">Sequential</span><span class=\"p\">()</span>\n",
-       "    <span class=\"n\">model</span><span class=\"o\">.</span><span class=\"n\">add</span><span class=\"p\">(</span><span class=\"n\">Dense</span><span class=\"p\">(</span><span class=\"n\">encoding_size</span><span class=\"p\">,</span> <span class=\"n\">input_dim</span><span class=\"o\">=</span><span class=\"n\">input_size</span><span class=\"p\">,</span> <span class=\"n\">activation</span><span class=\"o\">=</span><span class=\"s1\">&#39;relu&#39;</span><span class=\"p\">,</span> <span class=\"n\">kernel_initializer</span><span class=\"o\">=</span><span class=\"s1\">&#39;random_uniform&#39;</span><span class=\"p\">,</span><span class=\"n\">bias_initializer</span><span class=\"o\">=</span><span class=\"s1\">&#39;ones&#39;</span><span class=\"p\">))</span>\n",
+       "    <span class=\"n\">model</span><span class=\"o\">.</span><span class=\"n\">add</span><span class=\"p\">(</span><span class=\"n\">Dense</span><span class=\"p\">(</span><span class=\"n\">encoding_size</span><span class=\"p\">,</span> <span class=\"n\">input_dim</span><span class=\"o\">=</span><span class=\"n\">input_size</span><span class=\"p\">,</span> <span class=\"n\">activation</span><span class=\"o\">=</span><span class=\"s1\">&#39;relu&#39;</span><span class=\"p\">,</span> <span class=\"n\">kernel_initializer</span><span class=\"o\">=</span><span class=\"s1\">&#39;random_uniform&#39;</span><span class=\"p\">,</span>\n",
+       "                    <span class=\"n\">bias_initializer</span><span class=\"o\">=</span><span class=\"s1\">&#39;ones&#39;</span><span class=\"p\">))</span>\n",
        "    <span class=\"n\">model</span><span class=\"o\">.</span><span class=\"n\">add</span><span class=\"p\">(</span><span class=\"n\">Dense</span><span class=\"p\">(</span><span class=\"n\">input_size</span><span class=\"p\">,</span> <span class=\"n\">activation</span><span class=\"o\">=</span><span class=\"s1\">&#39;relu&#39;</span><span class=\"p\">,</span> <span class=\"n\">kernel_initializer</span><span class=\"o\">=</span><span class=\"s1\">&#39;random_uniform&#39;</span><span class=\"p\">,</span> <span class=\"n\">bias_initializer</span><span class=\"o\">=</span><span class=\"s1\">&#39;ones&#39;</span><span class=\"p\">))</span>\n",
+       "\n",
        "    <span class=\"c1\"># update model with sgd</span>\n",
        "    <span class=\"n\">sgd</span> <span class=\"o\">=</span> <span class=\"n\">optimizers</span><span class=\"o\">.</span><span class=\"n\">SGD</span><span class=\"p\">(</span><span class=\"n\">lr</span><span class=\"o\">=</span><span class=\"mf\">0.01</span><span class=\"p\">)</span>\n",
        "    <span class=\"n\">model</span><span class=\"o\">.</span><span class=\"n\">compile</span><span class=\"p\">(</span><span class=\"n\">loss</span><span class=\"o\">=</span><span class=\"s1\">&#39;mean_squared_error&#39;</span><span class=\"p\">,</span> <span class=\"n\">optimizer</span><span class=\"o\">=</span><span class=\"n\">sgd</span><span class=\"p\">,</span> <span class=\"n\">metrics</span><span class=\"o\">=</span><span class=\"p\">[</span><span class=\"s1\">&#39;accuracy&#39;</span><span class=\"p\">])</span>\n",
@@ -431,7 +474,7 @@
     }
    ],
    "source": [
-    "psource(auto_encoder_learner)"
+    "psource(AutoencoderLearner)"
    ]
   },
   {
@@ -458,7 +501,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.2"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,

--- a/notebooks/chapter19/RNN.ipynb
+++ b/notebooks/chapter19/RNN.ipynb
@@ -53,35 +53,13 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Using TensorFlow backend.\n",
-      "/usr/local/lib/python3.6/dist-packages/tensorflow/python/framework/dtypes.py:516: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.\n",
-      "  _np_qint8 = np.dtype([(\"qint8\", np.int8, 1)])\n",
-      "/usr/local/lib/python3.6/dist-packages/tensorflow/python/framework/dtypes.py:517: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.\n",
-      "  _np_quint8 = np.dtype([(\"quint8\", np.uint8, 1)])\n",
-      "/usr/local/lib/python3.6/dist-packages/tensorflow/python/framework/dtypes.py:518: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.\n",
-      "  _np_qint16 = np.dtype([(\"qint16\", np.int16, 1)])\n",
-      "/usr/local/lib/python3.6/dist-packages/tensorflow/python/framework/dtypes.py:519: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.\n",
-      "  _np_quint16 = np.dtype([(\"quint16\", np.uint16, 1)])\n",
-      "/usr/local/lib/python3.6/dist-packages/tensorflow/python/framework/dtypes.py:520: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.\n",
-      "  _np_qint32 = np.dtype([(\"qint32\", np.int32, 1)])\n",
-      "/usr/local/lib/python3.6/dist-packages/tensorflow/python/framework/dtypes.py:525: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.\n",
-      "  np_resource = np.dtype([(\"resource\", np.ubyte, 1)])\n",
-      "/usr/local/lib/python3.6/dist-packages/tensorboard/compat/tensorflow_stub/dtypes.py:541: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.\n",
-      "  _np_qint8 = np.dtype([(\"qint8\", np.int8, 1)])\n",
-      "/usr/local/lib/python3.6/dist-packages/tensorboard/compat/tensorflow_stub/dtypes.py:542: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.\n",
-      "  _np_quint8 = np.dtype([(\"quint8\", np.uint8, 1)])\n",
-      "/usr/local/lib/python3.6/dist-packages/tensorboard/compat/tensorflow_stub/dtypes.py:543: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.\n",
-      "  _np_qint16 = np.dtype([(\"qint16\", np.int16, 1)])\n",
-      "/usr/local/lib/python3.6/dist-packages/tensorboard/compat/tensorflow_stub/dtypes.py:544: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.\n",
-      "  _np_quint16 = np.dtype([(\"quint16\", np.uint16, 1)])\n",
-      "/usr/local/lib/python3.6/dist-packages/tensorboard/compat/tensorflow_stub/dtypes.py:545: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.\n",
-      "  _np_qint32 = np.dtype([(\"qint32\", np.int32, 1)])\n",
-      "/usr/local/lib/python3.6/dist-packages/tensorboard/compat/tensorflow_stub/dtypes.py:550: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.\n",
-      "  np_resource = np.dtype([(\"resource\", np.ubyte, 1)])\n"
+      "Using TensorFlow backend.\n"
      ]
     }
    ],
    "source": [
+    "import warnings\n",
+    "warnings.filterwarnings(\"ignore\", category=FutureWarning)\n",
     "import os, sys\n",
     "sys.path = [os.path.abspath(\"../../\")] + sys.path\n",
     "from deep_learning4e import *\n",
@@ -271,10 +249,10 @@
      "output_type": "stream",
      "text": [
       "WARNING: Logging before flag parsing goes to stderr.\n",
-      "W1018 11:18:25.754184 139973198665536 deprecation.py:323] From /usr/local/lib/python3.6/dist-packages/tensorflow/python/ops/nn_impl.py:180: add_dispatch_support.<locals>.wrapper (from tensorflow.python.ops.array_ops) is deprecated and will be removed in a future version.\n",
+      "W1018 22:51:23.614058 140557804885824 deprecation.py:323] From /usr/local/lib/python3.6/dist-packages/tensorflow/python/ops/nn_impl.py:180: add_dispatch_support.<locals>.wrapper (from tensorflow.python.ops.array_ops) is deprecated and will be removed in a future version.\n",
       "Instructions for updating:\n",
       "Use tf.where in 2.0, which has the same broadcast rule as np.where\n",
-      "W1018 11:18:26.423906 139973198665536 deprecation_wrapper.py:119] From /usr/local/lib/python3.6/dist-packages/keras/backend/tensorflow_backend.py:422: The name tf.global_variables is deprecated. Please use tf.compat.v1.global_variables instead.\n",
+      "W1018 22:51:24.267649 140557804885824 deprecation_wrapper.py:119] From /usr/local/lib/python3.6/dist-packages/keras/backend/tensorflow_backend.py:422: The name tf.global_variables is deprecated. Please use tf.compat.v1.global_variables instead.\n",
       "\n"
      ]
     },
@@ -284,25 +262,25 @@
      "text": [
       "Train on 24990 samples, validate on 25000 samples\n",
       "Epoch 1/10\n",
-      " - 62s - loss: 0.6675 - accuracy: 0.5692 - val_loss: 0.6368 - val_accuracy: 0.6248\n",
+      " - 59s - loss: 0.6540 - accuracy: 0.5959 - val_loss: 0.6234 - val_accuracy: 0.6488\n",
       "Epoch 2/10\n",
-      " - 63s - loss: 0.5553 - accuracy: 0.7174 - val_loss: 0.5038 - val_accuracy: 0.7612\n",
+      " - 61s - loss: 0.5977 - accuracy: 0.6766 - val_loss: 0.6202 - val_accuracy: 0.6326\n",
       "Epoch 3/10\n",
-      " - 64s - loss: 0.4703 - accuracy: 0.7925 - val_loss: 0.5607 - val_accuracy: 0.7427\n",
+      " - 61s - loss: 0.5269 - accuracy: 0.7356 - val_loss: 0.4803 - val_accuracy: 0.7789\n",
       "Epoch 4/10\n",
-      " - 62s - loss: 0.5701 - accuracy: 0.6976 - val_loss: 0.6186 - val_accuracy: 0.6440\n",
+      " - 61s - loss: 0.4159 - accuracy: 0.8130 - val_loss: 0.5640 - val_accuracy: 0.7046\n",
       "Epoch 5/10\n",
-      " - 67s - loss: 0.5079 - accuracy: 0.7602 - val_loss: 0.5736 - val_accuracy: 0.7152\n",
+      " - 61s - loss: 0.3931 - accuracy: 0.8294 - val_loss: 0.4707 - val_accuracy: 0.8090\n",
       "Epoch 6/10\n",
-      " - 64s - loss: 0.5645 - accuracy: 0.7066 - val_loss: 0.5814 - val_accuracy: 0.6827\n",
+      " - 61s - loss: 0.3357 - accuracy: 0.8637 - val_loss: 0.4177 - val_accuracy: 0.8122\n",
       "Epoch 7/10\n",
-      " - 65s - loss: 0.4510 - accuracy: 0.7918 - val_loss: 0.5198 - val_accuracy: 0.7439\n",
+      " - 61s - loss: 0.3552 - accuracy: 0.8594 - val_loss: 0.4652 - val_accuracy: 0.7889\n",
       "Epoch 8/10\n",
-      " - 67s - loss: 0.4458 - accuracy: 0.7985 - val_loss: 0.6681 - val_accuracy: 0.6143\n",
+      " - 61s - loss: 0.3286 - accuracy: 0.8686 - val_loss: 0.4708 - val_accuracy: 0.7785\n",
       "Epoch 9/10\n",
-      " - 66s - loss: 0.5261 - accuracy: 0.7435 - val_loss: 0.5917 - val_accuracy: 0.7105\n",
+      " - 61s - loss: 0.3428 - accuracy: 0.8635 - val_loss: 0.4332 - val_accuracy: 0.8137\n",
       "Epoch 10/10\n",
-      " - 64s - loss: 0.5762 - accuracy: 0.6814 - val_loss: 0.6450 - val_accuracy: 0.5956\n"
+      " - 61s - loss: 0.3650 - accuracy: 0.8471 - val_loss: 0.4673 - val_accuracy: 0.7914\n"
      ]
     }
    ],


### PR DESCRIPTION
Fixing the names in the notebook notebooks/chapter19.RNN.ipynb according to the names used in deep_learning4e.py

As an aside, the training run with SimpleRNNLearner gives a lower validation accuracy:
```
...
Epoch 10/10
 - 64s - loss: 0.5762 - accuracy: 0.6814 - val_loss: 0.6450 - val_accuracy: 0.5956
```

It was tested with the following packages:
```
Name: tensorflow
Version: 1.14.0
Summary: TensorFlow is an open source machine learning framework for everyone.
Home-page: https://www.tensorflow.org/
Author: Google Inc.
Author-email: packages@tensorflow.org
License: Apache 2.0
Location: /usr/local/lib/python3.6/dist-packages
Requires: grpcio, termcolor, gast, wheel, tensorboard, six, keras-preprocessing, tensorflow-estimator, wrapt, protobuf, absl-py, astor, keras-applications, numpy, google-pasta
Required-by: tensorflow-serving-api, Entailment
---
Name: Keras
Version: 2.3.0
Summary: Deep Learning for humans
Home-page: https://github.com/keras-team/keras
Author: Francois Chollet
Author-email: francois.chollet@gmail.com
License: MIT
Location: /usr/local/lib/python3.6/dist-packages
Requires: six, scipy, h5py, keras-preprocessing, keras-applications, pyyaml, numpy
Required-by: 
```