### PR TITLE
fixed grabbing behaviour in agent

### DIFF
--- a/agents.py
+++ b/agents.py
@@ -510,14 +510,16 @@ class XYEnvironment(Environment):
             agent.direction += Direction.L
         elif action == 'Forward':
             agent.bump = self.move_to(agent, agent.direction.move_forward(agent.location))
-        #         elif action == 'Grab':
-        #             things = [thing for thing in self.list_things_at(agent.location)
-        #                     if agent.can_grab(thing)]
-        #             if things:
-        #                 agent.holding.append(things[0])
+        elif action == 'Grab':
+            things = [thing for thing in self.list_things_at(agent.location)]
+            if agent.can_grab(things[0]):
+                if things:
+                    agent.holding.append(things[0])
+                    self.delete_thing(things[0])
         elif action == 'Release':
             if agent.holding:
-                agent.holding.pop()
+                dropped = agent.holding.pop()
+                self.add_thing(dropped, location=agent.location)
 
     def default_location(self, thing):
         location = self.random_location_inbounds()
@@ -569,10 +571,11 @@ class XYEnvironment(Environment):
     def delete_thing(self, thing):
         """Deletes thing, and everything it is holding (if thing is an agent)"""
         if isinstance(thing, Agent):
-            for obj in thing.holding:
-                super().delete_thing(obj)
-                for obs in self.observers:
-                    obs.thing_deleted(obj)
+            # for obj in thing.holding:
+            #     super().delete_thing(obj)
+            #     for obs in self.observers:
+            #         obs.thing_deleted(obj)
+            del thing.holding
 
         super().delete_thing(thing)
         for obs in self.observers:

--- a/agents.py
+++ b/agents.py
@@ -959,9 +959,9 @@ class WumpusEnvironment(XYEnvironment):
 
         if isinstance(agent, Explorer) and self.in_danger(agent):
             return
-
+            
         agent.bump = False
-        if action in ['TurnRight', 'TurnLeft', 'Forward','Grab']:
+        if action in ['TurnRight', 'TurnLeft', 'Forward', 'Grab']:
             super().execute_action(agent,action)
             agent.performance -= 1
         elif action == 'Climb':

--- a/agents.py
+++ b/agents.py
@@ -511,14 +511,15 @@ class XYEnvironment(Environment):
         elif action == 'Forward':
             agent.bump = self.move_to(agent, agent.direction.move_forward(agent.location))
         elif action == 'Grab':
-            things = [thing for thing in self.list_things_at(agent.location)]
-            if agent.can_grab(things[0]):
-                if things:
-                    agent.holding.append(things[0])
-                    self.delete_thing(things[0])
+            things = [thing for thing in self.list_things_at(agent.location) if agent.can_grab(thing)]
+            if things:    
+                agent.holding.append(things[0])
+                print("Grabbing ", things[0].__class__.__name__)
+                self.delete_thing(things[0])
         elif action == 'Release':
             if agent.holding:
                 dropped = agent.holding.pop()
+                print("Dropping ", dropped.__class__.__name__)
                 self.add_thing(dropped, location=agent.location)
 
     def default_location(self, thing):
@@ -571,10 +572,6 @@ class XYEnvironment(Environment):
     def delete_thing(self, thing):
         """Deletes thing, and everything it is holding (if thing is an agent)"""
         if isinstance(thing, Agent):
-            # for obj in thing.holding:
-            #     super().delete_thing(obj)
-            #     for obs in self.observers:
-            #         obs.thing_deleted(obj)
             del thing.holding
 
         super().delete_thing(thing)
@@ -970,21 +967,16 @@ class WumpusEnvironment(XYEnvironment):
 
         agent.bump = False
         if action == 'TurnRight':
-            agent.direction += Direction.R
+            super().execute_action(agent,action)
             agent.performance -= 1
         elif action == 'TurnLeft':
-            agent.direction += Direction.L
+            super().execute_action(agent,action)
             agent.performance -= 1
         elif action == 'Forward':
-            agent.bump = self.move_to(agent, agent.direction.move_forward(agent.location))
+            super().execute_action(agent,action)
             agent.performance -= 1
         elif action == 'Grab':
-            things = [thing for thing in self.list_things_at(agent.location)
-                      if agent.can_grab(thing)]
-            if len(things):
-                print("Grabbing", things[0].__class__.__name__)
-                if len(things):
-                    agent.holding.append(things[0])
+            super().execute_action(agent,action)
             agent.performance -= 1
         elif action == 'Climb':
             if agent.location == (1, 1):  # Agent can only climb out of (1,1)

--- a/agents.py
+++ b/agents.py
@@ -962,7 +962,7 @@ class WumpusEnvironment(XYEnvironment):
             
         agent.bump = False
         if action in ['TurnRight', 'TurnLeft', 'Forward', 'Grab']:
-            super().execute_action(agent,action)
+            super().execute_action(agent, action)
             agent.performance -= 1
         elif action == 'Climb':
             if agent.location == (1, 1):  # Agent can only climb out of (1,1)

--- a/agents.py
+++ b/agents.py
@@ -27,11 +27,6 @@ EnvCanvas ## Canvas to display the environment of an EnvGUI
 """
 
 # TODO
-# Implement grabbing correctly.
-# When an object is grabbed, does it still have a location?
-# What if it is released?
-# What if the grabbed or the grabber is deleted?
-# What if the grabber moves?
 # Speed control in GUI does not have any effect -- fix it.
 
 from utils import distance_squared, turn_heading
@@ -966,16 +961,7 @@ class WumpusEnvironment(XYEnvironment):
             return
 
         agent.bump = False
-        if action == 'TurnRight':
-            super().execute_action(agent,action)
-            agent.performance -= 1
-        elif action == 'TurnLeft':
-            super().execute_action(agent,action)
-            agent.performance -= 1
-        elif action == 'Forward':
-            super().execute_action(agent,action)
-            agent.performance -= 1
-        elif action == 'Grab':
+        if action in ['TurnRight', 'TurnLeft', 'Forward','Grab']:
             super().execute_action(agent,action)
             agent.performance -= 1
         elif action == 'Climb':


### PR DESCRIPTION
When a thing is grabbed, it would be hidden from the environment. When released or the agent is removed it would be added to environment again at the same location of the agent. For the issue of grabbed thing movement, it is already implemented. No test has failed.

Have I missed something?