### PR TITLE
Imported utils4e to resolve some dependency bugs

### DIFF
--- a/search.py
+++ b/search.py
@@ -10,6 +10,7 @@ import sys
 from collections import deque
 
 from utils import *
+from utils4e import *
 
 
 class Problem:


### PR DESCRIPTION
For example, `best_first_graph_search` and `astar_search` don 't work without this line. They need to use `memoize` and `PriorityQueue`, that only can be imported from utils4e.