### PR TITLE
feat: add astar_tree_search best_first_tree_search uniform_cost_tree_…

### DIFF
--- a/search.py
+++ b/search.py
@@ -256,6 +256,27 @@ def breadth_first_graph_search(problem):
                 frontier.append(child)
     return None
 
+def best_first_tree_search(problem, f, display=False):
+    """Search the nodes with the lowest f scores first.
+    You specify the function f(node) that you want to minimize; for example,
+    if f is a heuristic estimate to the goal, then we have greedy best
+    first search; if f is node.depth then we have breadth-first search.
+    There is a subtlety: the line "f = memoize(f, 'f')" means that the f
+    values will be cached on the nodes as they are computed. So after doing
+    a best first search you can examine the f values of the path returned."""
+    f = memoize(f, 'f')
+    node = Node(problem.initial)
+    frontier = PriorityQueue('min', f)
+    frontier.append(node)
+    while frontier:
+        node = frontier.pop()
+        if problem.goal_test(node.state):
+            if display:
+                print(len(frontier), "paths remain in the frontier")
+            return node
+
+        [frontier.append(child) for child in [problem.result(node.state, action) for action in problem.actions(node.state)]]
+    return None
 
 def best_first_graph_search(problem, f, display=False):
     """Search the nodes with the lowest f scores first.
@@ -286,6 +307,9 @@ def best_first_graph_search(problem, f, display=False):
                     frontier.append(child)
     return None
 
+def uniform_cost_tree_search(problem, display=False):
+    """[Figure 3.14]"""
+    return best_first_tree_search(problem, lambda node: node.path_cost, display)
 
 def uniform_cost_search(problem, display=False):
     """[Figure 3.14]"""
@@ -411,6 +435,15 @@ greedy_best_first_graph_search = best_first_graph_search
 
 # Greedy best-first search is accomplished by specifying f(n) = h(n).
 
+def astar_tree_search(problem, h=None, display=False):
+    """A* tree search in an adpatation from A* graph search with f(n) = g(n)+h(n).
+    You need to specify the h function when you call astar_tree_search, or
+    else in your Problem subclass.
+    Note: this function has speed improvement when compared to regular astar_search
+    applied to a tree problem
+    """
+    h = memoize(h or problem.h, 'h')
+    return best_first_tree_search(problem, lambda n: n.path_cost + h(n), display)
 
 def astar_search(problem, h=None, display=False):
     """A* search is best-first graph search with f(n) = g(n)+h(n).


### PR DESCRIPTION
**Associated with issue** -> Feat: Add best_first_tree_search #1202

**To sum up :**
We propose the addition of the following functions to search.py:

- best_first_tree_search
- uniform_cost_tree_search
- astar_tree_search+

**Our background and motivation**
Me (Marcelo Jacinto), João Silva and David Souto are 3 students from Electrical and Computer Engineering at Instituto Superior Técnico (Lisbon) that are taking a course on AI. We were solving a search problem whose structure is a tree and not a graph. We are required to use aima-python for the project (in order focus only on the logic side of the problem), but we figured out (using cProfiler) that using the a_star_search implementation for aima-python is much slower than our costume one - because it is currently implemented for graphs in general and its making checks in order to avoid loops (which in trees are impossible to occur).

In our simple problem we checked that the eq function was already consuming about 11s of the total of 30s the problem takes to be solved using aima-python current implementation.