### PR TITLE
fix lcv heuristic

### DIFF
--- a/csp.py
+++ b/csp.py
@@ -371,7 +371,10 @@ def unordered_domain_values(var, assignment, csp):
 
 def lcv(var, assignment, csp):
     """Least-constraining-values heuristic."""
-    return sorted(csp.choices(var), key=lambda val: csp.nconflicts(var, val, assignment))
+    return sorted(csp.choices(var), key=lambda val: sum(not csp.constraints(var, val, unass_var, unass_val)
+                                                          for unass_var in csp.neighbors[var]
+                                                          if unass_var not in assignment
+                                                          for unass_val in csp.choices(unass_var)))
 
 
 # Inference


### PR DESCRIPTION
The lcv heuristic should check how many values are ruled out for unassigned variables.
Instead, the use of csp.nconflicts method in sorting key counts the number of conflicts with yet assigned variables.