### PR TITLE
Fixed misleading comments on csp.py

### DIFF
--- a/csp.py
+++ b/csp.py
@@ -185,7 +185,7 @@ def AC3(csp, queue=None, removals=None, arc_heuristic=dom_j_up):
             for Xk in csp.neighbors[Xi]:
                 if Xk != Xj:
                     queue.add((Xk, Xi))
-    return True, checks  # CSP is satisfiable
+    return True, checks  # CSP is arc-consistent
 
 
 def revise(csp, Xi, Xj, removals, checks=0):
@@ -257,7 +257,7 @@ def AC3b(csp, queue=None, removals=None, arc_heuristic=dom_j_up):
                 for Xk in csp.neighbors[Xj]:
                     if Xk != Xi:
                         queue.add((Xk, Xj))
-    return True, checks  # CSP is satisfiable
+    return True, checks  # CSP is arc-consistent
 
 
 def partition(csp, Xi, Xj, checks=0):
@@ -334,7 +334,7 @@ def AC4(csp, queue=None, removals=None, arc_heuristic=dom_j_up):
             if revised:
                 if not csp.curr_domains[Xi]:
                     return False, checks  # CSP is inconsistent
-    return True, checks  # CSP is satisfiable
+    return True, checks  # CSP is arc-consistent
 
 
 # ______________________________________________________________________________


### PR DESCRIPTION
Changed AC3 comments previously suggesting that: **If AC3 returns True, the CSP instance is Satisfiable.**

However, that is not true in the general case, as suggested in [Wikipedia](https://en.wikipedia.org/wiki/Local_consistency#Consistency_and_satisfiability) and also in the textbook, under figure 6.3, suggesting that AC3 might be *powerless* at some specific unsatisfiable (Map Coloring) instances.