### PR TITLE
Update utils4e.py

### DIFF
--- a/utils4e.py
+++ b/utils4e.py
@@ -317,11 +317,11 @@ def rms_error(x, y):
 
 
 def ms_error(x, y):
-    return mean((x - y) ** 2 for x, y in zip(x, y))
+    return mean((_x - _y) ** 2 for _x, _y in zip(x, y))
 
 
 def mean_error(x, y):
-    return mean(abs(x - y) for x, y in zip(x, y))
+    return mean(abs(_x - _y) for _x, _y in zip(x, y))
 
 
 def mean_boolean_error(x, y):
@@ -334,7 +334,7 @@ def mean_boolean_error(x, y):
 
 def cross_entropy_loss(x, y):
     """Cross entropy loss function. x and y are 1D iterable objects."""
-    return (-1.0 / len(x)) * sum(x * np.log(_y) + (1 - _x) * np.log(1 - _y) for _x, _y in zip(x, y))
+    return (-1.0 / len(x)) * sum(_x * np.log(_y) + (1 - _x) * np.log(1 - _y) for _x, _y in zip(x, y))
 
 
 def mean_squared_error_loss(x, y):


### PR DESCRIPTION
there was a typo in line 377 which made the formula for cross_entropy_loss Wrong.

line 320, 324 so that it looks similar to above function definitions.