### PR TITLE
Fixed an import error of to_categorical() from tensorflow.keras.utils…

### DIFF
--- a/perception4e.py
+++ b/perception4e.py
@@ -8,6 +8,7 @@ import scipy.signal
 from keras.datasets import mnist
 from keras.layers import Dense, Activation, Flatten, InputLayer, Conv2D, MaxPooling2D
 from keras.models import Sequential
+from tensorflow.keras.utils import to_categorical
 
 from utils4e import gaussian_kernel_2D
 
@@ -309,8 +310,8 @@ def load_MINST(train_size, val_size, test_size):
     x_train /= 255
     test_x = x_test.astype('float32')
     test_x /= 255
-    y_train = keras.utils.to_categorical(y_train, 10)
-    y_test = keras.utils.to_categorical(y_test, 10)
+    y_train = to_categorical(y_train, 10)
+    y_test = to_categorical(y_test, 10)
     return ((x_train[:train_size], y_train[:train_size]),
             (x_train[train_size:train_size + val_size], y_train[train_size:train_size + val_size]),
             (x_test[:test_size], y_test[:test_size]))


### PR DESCRIPTION
There seem to be an issue with importing to_categorical from `keras.utils`. Importing the method from `tensorflow.keras.utils` seem to resolve the issue. The issue is present on both Python 3.7 and 3.8.

- Tensorflow=2.5.0
- Keras=2.4.3

[packages.txt](https://github.com/aimacode/aima-python/files/6609613/packages.txt)
