### PR TITLE
Update the attribute error associated with pad_sequences

### DIFF
--- a/deep_learning4e.py
+++ b/deep_learning4e.py
@@ -6,7 +6,7 @@ import statistics
 import numpy as np
 from keras import Sequential, optimizers
 from keras.layers import Embedding, SimpleRNN, Dense
-from keras.preprocessing import sequence
+from keras.utils import pad_sequences # version 2.9
 
 from utils4e import (conv1D, gaussian_kernel, element_wise_product, vector_add, random_weights,
                      scalar_vector_product, map_vector, mean_squared_error_loss)
@@ -518,8 +518,8 @@ def keras_dataset_loader(dataset, max_length=500):
     # init dataset
     (X_train, y_train), (X_val, y_val) = dataset
     if max_length > 0:
-        X_train = sequence.pad_sequences(X_train, maxlen=max_length)
-        X_val = sequence.pad_sequences(X_val, maxlen=max_length)
+        X_train = pad_sequences(X_train, maxlen=max_length)
+        X_val = pad_sequences(X_val, maxlen=max_length)
     return (X_train[10:], y_train[10:]), (X_val, y_val), (X_train[:10], y_train[:10])
 
 


### PR DESCRIPTION
Found an error while running py.test. I figured out that the module 'keras.preprocessing.sequence' has no attribute 'pad_sequences' in keras 2.9. Thus, I updated the deep_learning4e.py to reflect the latest update in keras.