### PR TITLE
Fix bug in all_events

### DIFF
--- a/probability4e.py
+++ b/probability4e.py
@@ -591,9 +591,12 @@ def all_events(variables, bn, e):
     else:
         X, rest = variables[0], variables[1:]
         for e1 in all_events(rest, bn, e):
-            for x in bn.variable_values(X):
-                yield extend(e1, X, x)
-
+            if X in e:
+                yield e1
+            else:
+                for x in bn.variable_values(X):
+                    yield extend(e1, X, x)
+                    
 
 # ______________________________________________________________________________
 # 13.3.4 Clustering algorithms


### PR DESCRIPTION
In case any `variables` exist in `e`, the former implementation would generate wrong results.
```py
all_events("Alarm", alarm_net, {"Earthquake": F}) # before, would yield event with E: F
```