### PR TITLE
Resolve #1269. Changed the return of the accuracy score

### DIFF
--- a/learning4e.py
+++ b/learning4e.py
@@ -910,7 +910,7 @@ def weighted_replicate(seq, weights, n):
 
 def accuracy_score(y_pred, y_true):
     assert y_pred.shape == y_true.shape
-    return np.mean(np.equal(y_pred, y_true))
+    return np.mean(y_pred == y_true)
 
 
 def r2_score(y_pred, y_true):


### PR DESCRIPTION
As suggested by the Issue#1269, I tried to replace <code>np.mean(np.equal(y_pred, y_true))</code> with <code>return np.mean(y_pred == y_true)</code> to include string element comparisons.
I ran the tests before and after the changes, and in both cases test_learning4e.py completed successfully. 


![1](https://github.com/aimacode/aima-python/assets/79763286/b25cbcbd-ee4a-42f6-bf77-a70bc0579bf2)
![2](https://github.com/aimacode/aima-python/assets/79763286/345b6881-4b89-4cd1-a97f-04a473d81ae1)
