### PR TITLE
Update: argument in optimizers.SGD from lr to learning_rate

### DIFF
--- a/deep_learning4e.py
+++ b/deep_learning4e.py
@@ -575,7 +575,7 @@ def AutoencoderLearner(inputs, encoding_size, epochs=200, verbose=False):
     model.add(Dense(input_size, activation='relu', kernel_initializer='random_uniform', bias_initializer='ones'))
 
     # update model with sgd
-    sgd = optimizers.SGD(lr=0.01)
+    sgd = optimizers.SGD(learning_rate=0.01)
     model.compile(loss='mean_squared_error', optimizer=sgd, metrics=['accuracy'])
 
     # train the model


### PR DESCRIPTION
Running the tests provide a failed test in deep_learning4e.py due to recent changes in Keras, the argument lr has been changed to learning_rate.