### PR TITLE
Fix off-by-one error in defining the start and end of an XYEnvironment

### DIFF
--- a/agents.py
+++ b/agents.py
@@ -480,7 +480,7 @@ class XYEnvironment(Environment):
         self.observers = []
         # Sets iteration start and end (no walls).
         self.x_start, self.y_start = (0, 0)
-        self.x_end, self.y_end = (self.width, self.height)
+        self.x_end, self.y_end = (self.width - 1, self.height - 1)
 
     perceptible_distance = 1
 


### PR DESCRIPTION
When a new XYEnvironment object is created it is given attributes hight and width which are then used to assign the attributes x_end and y_end. However, the x_end and y_end should be one less than the width as the positional index starts at one.

By fixing this it ensures that the is_inbounds returns the correct value and environments can correctly check if things are inbounds.