### PR TITLE
Fix AttributeError in NQueensProblem (Issue #1308)

### DIFF
--- a/notebook.py
+++ b/notebook.py
@@ -1061,7 +1061,7 @@ def plot_NQueens(solution):
     board = np.array([2 * int((i + j) % 2) for j in range(n) for i in range(n)]).reshape((n, n))
     im = Image.open('images/queen_s.png')
     height = im.size[1]
-    im = np.array(im).astype(np.float) / 255
+    im = np.array(im).astype(float) / 255
     fig = plt.figure(figsize=(7, 7))
     ax = fig.add_subplot(111)
     ax.set_title('{} Queens'.format(n))

--- a/search.ipynb
+++ b/search.ipynb
@@ -1120,7 +1120,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1132,7 +1132,11 @@
     "    # we use these two variables at the time of visualisations\n",
     "    iterations = 0\n",
     "    all_node_colors = []\n",
-    "    node_colors = {k : 'white' for k in problem.graph.nodes()}\n",
+    "    if hasattr(problem, 'graph'):\n",
+    "        node_colors = {k : 'white' for k in problem.graph.nodes()}\n",
+    "    else:\n",
+    "        node_colors = {}\n",
+    "\n",
     "    \n",
     "    #Adding first node to the queue\n",
     "    frontier = deque([Node(problem.initial)])\n",
@@ -1208,7 +1212,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1220,7 +1224,10 @@
     "    # we use these two variables at the time of visualisations\n",
     "    iterations = 0\n",
     "    all_node_colors = []\n",
-    "    node_colors = {k : 'white' for k in problem.graph.nodes()}\n",
+    "    if hasattr(problem, 'graph'):\n",
+    "        node_colors = {k : 'white' for k in problem.graph.nodes()}\n",
+    "    else:\n",
+    "        node_colors = {}\n",
     "    \n",
     "    #Adding first node to the stack\n",
     "    frontier = [Node(problem.initial)]\n",
@@ -5305,13 +5312,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 83,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
    "outputs": [],
    "source": [
-    "dfts = depth_first_tree_search(nqp).solution()"
+    "_, _, goal_node = depth_first_tree_search(nqp)  # Unpack the tuple\n",
+    "dfts = goal_node.solution()"
    ]
   },
   {
@@ -5361,13 +5369,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
    "outputs": [],
    "source": [
-    "bfts = breadth_first_tree_search(nqp).solution()"
+    "_, _, goal_node = breadth_first_tree_search(nqp)  # Unpack the tuple\n",
+    "bfts = goal_node.solution()"
    ]
   },
   {


### PR DESCRIPTION
Fixes Issue #1308 

This PR fixes the _AttributeError: 'NQueensProblem' object has no attribute 'graph' in search.ipynb_. The issue occurs because `tree_depth_search_for_vis` expects a graph attribute, which NQueensProblem does not have.

Changes Made:
- Updated `tree_depth_search_for_vis` and `tree_breadth_search_for_vis` to handle problems without a graph attribute.
- Fixed tuple unpacking for `depth_first_tree_search(nqp)` and `breadth_first_tree_search(nqp)` to correctly access .solution().
- Replaced deprecated **np.float** with **float** in `plot_NQueens`.