### PR TITLE
Update deep_learning4e.py

### DIFF
--- a/deep_learning4e.py
+++ b/deep_learning4e.py
@@ -575,7 +575,7 @@ def AutoencoderLearner(inputs, encoding_size, epochs=200, verbose=False):
     model.add(Dense(input_size, activation='relu', kernel_initializer='random_uniform', bias_initializer='ones'))
 
     # update model with sgd
-    sgd = optimizers.SGD(lr=0.01)
+    sgd = optimizers.SGD(learning_rate=0.01)  # Keras ≥ 2.11 uses “learning_rate”
     model.compile(loss='mean_squared_error', optimizer=sgd, metrics=['accuracy'])
 
     # train the model


### PR DESCRIPTION
Keras 3 (and the late 2.15 nightly series) removed the old lr= alias. From those versions on, you must use the keyword learning_rate=.