### PR TITLE
Fix broken image paths in notebooks (remove files/ prefix)

### DIFF
--- a/mdp.ipynb
+++ b/mdp.ipynb
@@ -288,7 +288,7 @@
    "metadata": {},
    "source": [
     "Now let us implement the simple MDP in the image below. States A, B have actions X, Y available in them. Their probabilities are shown just above the arrows. We start with using MDP as base class for our CustomMDP. Obviously we need to make a few changes to suit our case. We make use of a transition matrix as our transitions are not very simple.\n",
-    "<img src=\"files/images/mdp-a.png\">"
+    "<img src=\"images/mdp-a.png\">"
    ]
   },
   {

--- a/probability.ipynb
+++ b/probability.ipynb
@@ -1288,7 +1288,7 @@
     "\n",
     "The example below where we implement the network shown in **Figure 14.3** of the book will make this more clear.\n",
     "\n",
-    "<img src=\"files/images/bayesnet.png\">\n",
+    "<img src=\"images/bayesnet.png\">\n",
     "\n",
     "The alarm node can be made as follows: "
    ]
@@ -3275,7 +3275,7 @@
    "source": [
     "The function **prior_sample** implements the algorithm described in **Figure 14.13** of the book. Nodes are sampled in the topological order. The old value of the event is passed as evidence for parent values. We will use the Bayesian Network in **Figure 14.12** to try out the **prior_sample**\n",
     "\n",
-    "<img src=\"files/images/sprinklernet.jpg\" height=\"500\" width=\"500\">\n",
+    "<img src=\"images/sprinklernet.jpg\" height=\"500\" width=\"500\">\n",
     "\n",
     "Traversing the graph in topological order is important.\n",
     "There are two possible topological orderings for this particular directed acyclic graph.\n",

--- a/reinforcement_learning.ipynb
+++ b/reinforcement_learning.ipynb
@@ -128,7 +128,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `sequential_decision_environment` is a GridMDP object as shown below. The rewards are **+1** and **-1** in the terminal states, and **-0.04** in the rest. <img src=\"files/images/mdp.png\"> Now we define actions and a policy similar to **Fig 21.1** in the book."
+    "The `sequential_decision_environment` is a GridMDP object as shown below. The rewards are **+1** and **-1** in the terminal states, and **-0.04** in the rest. <img src=\"images/mdp.png\"> Now we define actions and a policy similar to **Fig 21.1** in the book."
    ]
   },
   {


### PR DESCRIPTION
Follow-up to #1302. The same `files/images/...` prefix (a Jupyter classic artifact) is broken on GitHub and modern Jupyter — there is no `files/` directory, so the embedded diagrams don't render. The images all exist under `images/`.

Removes the `files/` prefix from the `<img>` tags in:
- `mdp.ipynb` (mdp-a.png)
- `probability.ipynb` (bayesnet.png, sprinklernet.jpg)
- `reinforcement_learning.ipynb` (mdp.png)

Verified each referenced image exists under `images/`. Pure path fix, no content changes.