### PR TITLE
Small fixes from @pctablet505: cross_entropy_loss bug + dead-code cleanup

### DIFF
--- a/agents4e.py
+++ b/agents4e.py
@@ -510,11 +510,6 @@ class XYEnvironment(Environment):
             agent.direction += Direction.L
         elif action == 'Forward':
             agent.bump = self.move_to(agent, agent.direction.move_forward(agent.location))
-        #         elif action == 'Grab':
-        #             things = [thing for thing in self.list_things_at(agent.location)
-        #                     if agent.can_grab(thing)]
-        #             if things:
-        #                 agent.holding.append(things[0])
         elif action == 'Release':
             if agent.holding:
                 agent.holding.pop()

--- a/utils4e.py
+++ b/utils4e.py
@@ -334,7 +334,7 @@ def mean_boolean_error(x, y):
 
 def cross_entropy_loss(x, y):
     """Cross entropy loss function. x and y are 1D iterable objects."""
-    return (-1.0 / len(x)) * sum(x * np.log(_y) + (1 - _x) * np.log(1 - _y) for _x, _y in zip(x, y))
+    return (-1.0 / len(x)) * sum(_x * np.log(_y) + (1 - _x) * np.log(1 - _y) for _x, _y in zip(x, y))
 
 
 def mean_squared_error_loss(x, y):


### PR DESCRIPTION
Combines two small fixes by @pctablet505 (their fork branches were deleted, so re-applied here with authorship preserved):
- utils4e.cross_entropy_loss used the parameter list x instead of the loop variable _x, returning an array instead of the scalar loss. (#1214)
- Remove the dead commented-out Grab block from XYEnvironment (Grab is handled by WumpusEnvironment). (#1215)

Supersedes #1214 and #1215.