### PR TITLE
Fix broken rl.py links in README (#1223 rebased)

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,10 +175,10 @@ Here is a table of algorithms, the figure, name of the algorithm in the book and
 | 19.3   | Version-Space-Learning            | `version_space_learning`      | [`knowledge.py`](knowledge.py)  | Done | Included |
 | 19.8   | Minimal-Consistent-Det            | `minimal_consistent_det`      | [`knowledge.py`](knowledge.py)  | Done | Included |
 | 19.12  | FOIL                              | `FOIL_container`              | [`knowledge.py`](knowledge.py)  | Done | Included |
-| 21.2   | Passive-ADP-Agent                 | `PassiveADPAgent`             | [`rl.py`][rl]                   | Done | Included |
-| 21.4   | Passive-TD-Agent                  | `PassiveTDAgent`              | [`rl.py`][rl]                   | Done | Included |
-| 21.8   | Q-Learning-Agent                  | `QLearningAgent`              | [`rl.py`][rl]                   | Done | Included |
-| 21.8   | SARSA-Agent                       | `SARSALearningAgent`          | [`rl.py`][rl]                   | Done | Included |
+| 21.2   | Passive-ADP-Agent                 | `PassiveADPAgent`             | [`reinforcement_learning.py`][rl]                   | Done | Included |
+| 21.4   | Passive-TD-Agent                  | `PassiveTDAgent`              | [`reinforcement_learning.py`][rl]                   | Done | Included |
+| 21.8   | Q-Learning-Agent                  | `QLearningAgent`              | [`reinforcement_learning.py`][rl]                   | Done | Included |
+| 21.8   | SARSA-Agent                       | `SARSALearningAgent`          | [`reinforcement_learning.py`][rl]                   | Done | Included |
 | 22.1   | HITS                              | `HITS`                        | [`nlp.py`][nlp]                 | Done | Included |
 | 23     | Chart-Parse                       | `Chart`                       | [`nlp.py`][nlp]                 | Done | Included |
 | 23.5   | CYK-Parse                         | `CYK_parse`                   | [`nlp.py`][nlp]                 | Done | Included |
@@ -217,7 +217,7 @@ Many thanks for contributions over the years. I got bug reports, corrected code,
 [nlp]:../master/nlp.py
 [planning]:../master/planning.py
 [probability]:../master/probability.py
-[rl]:../master/rl.py
+[rl]:../master/reinforcement_learning.py
 [search]:../master/search.py
 [utils]:../master/utils.py
 [text]:../master/text.py


### PR DESCRIPTION
Rebuild of #1223 by @rongxin-liu (fork branch gone): rl.py was renamed reinforcement_learning.py; fix the broken README links (now also covers the SARSA row added since). Supersedes #1223.