### PR TITLE
query_player: re-prompt until a legal move (#1078 rebased)

### DIFF
--- a/games.py
+++ b/games.py
@@ -183,11 +183,15 @@ def query_player(game, state):
     print("")
     move = None
     if game.actions(state):
-        move_string = input('Your move? ')
-        try:
-            move = eval(move_string)
-        except NameError:
-            move = move_string
+        while True:
+            move_string = input('Your move? ')
+            try:
+                move = eval(move_string)
+            except NameError:
+                move = move_string
+            if move in game.actions(state):
+                break
+            print('illegal move, try again')
     else:
         print('no legal moves: passing turn to next player')
     return move


### PR DESCRIPTION
Rebuild of #1078 by @SandersLin (fork branch gone): make the interactive query_player loop until the user enters a legal move instead of accepting any input. Supersedes #1078.