### PR TITLE
Fix LinearLearner / LogisticLinearLeaner (shape mismatch) (#1254)

### DIFF
--- a/learning.py
+++ b/learning.py
@@ -511,8 +511,8 @@ def LinearLearner(dataset, learning_rate=0.01, epochs=100):
     examples = dataset.examples
     num_examples = len(examples)
 
-    # X transpose
-    X_col = [dataset.values[i] for i in idx_i]  # vertical columns of X
+    # X transpose: the actual value of each input feature across the examples
+    X_col = [[example[i] for example in examples] for i in idx_i]  # vertical columns of X
 
     # add dummy
     ones = [1 for _ in range(len(examples))]
@@ -526,7 +526,7 @@ def LinearLearner(dataset, learning_rate=0.01, epochs=100):
         err = []
         # pass over all examples
         for example in examples:
-            x = [1] + example
+            x = [1] + [example[i] for i in idx_i]
             y = np.dot(w, x)
             t = example[idx_t]
             err.append(t - y)
@@ -536,7 +536,7 @@ def LinearLearner(dataset, learning_rate=0.01, epochs=100):
             w[i] = w[i] + learning_rate * (np.dot(err, X_col[i]) / num_examples)
 
     def predict(example):
-        x = [1] + example
+        x = [1] + [example[i] for i in idx_i]
         return np.dot(w, x)
 
     return predict
@@ -552,8 +552,8 @@ def LogisticLinearLeaner(dataset, learning_rate=0.01, epochs=100):
     examples = dataset.examples
     num_examples = len(examples)
 
-    # X transpose
-    X_col = [dataset.values[i] for i in idx_i]  # vertical columns of X
+    # X transpose: the actual value of each input feature across the examples
+    X_col = [[example[i] for example in examples] for i in idx_i]  # vertical columns of X
 
     # add dummy
     ones = [1 for _ in range(len(examples))]
@@ -568,7 +568,7 @@ def LogisticLinearLeaner(dataset, learning_rate=0.01, epochs=100):
         h = []
         # pass over all examples
         for example in examples:
-            x = [1] + example
+            x = [1] + [example[i] for i in idx_i]
             y = sigmoid(np.dot(w, x))
             h.append(sigmoid_derivative(y))
             t = example[idx_t]
@@ -580,7 +580,7 @@ def LogisticLinearLeaner(dataset, learning_rate=0.01, epochs=100):
             w[i] = w[i] + learning_rate * (np.dot(buffer, X_col[i]) / num_examples)
 
     def predict(example):
-        x = [1] + example
+        x = [1] + [example[i] for i in idx_i]
         return sigmoid(np.dot(w, x))
 
     return predict

--- a/tests/test_learning.py
+++ b/tests/test_learning.py
@@ -114,6 +114,14 @@ def test_neural_network_learner():
     assert err_ratio(nnl, iris) < 0.21
 
 
+def test_linear_learner():
+    iris = DataSet(name="iris")
+    iris.classes_to_numbers()
+    # both linear learners should train and produce a numeric prediction without shape errors
+    assert isinstance(float(LinearLearner(iris)(iris.examples[0][:-1])), float)
+    assert isinstance(float(LogisticLinearLeaner(iris)(iris.examples[0][:-1])), float)
+
+
 def test_perceptron():
     iris = DataSet(name='iris')
     iris.classes_to_numbers()


### PR DESCRIPTION
Both linear learners were broken: they used x = [1] + example (the full example, incl. target) against inputs+bias-sized weights -> 'shapes not aligned' ValueError, and built X_col from dataset.values (possible values) instead of the actual feature columns. Fixed both + added a test. Fixes #1254.