### PR TITLE
Fix terminal Q-value in QLearningAgent/SARSA (use r, not r1) (#1247)

### DIFF
--- a/reinforcement_learning.py
+++ b/reinforcement_learning.py
@@ -290,7 +290,7 @@ class QLearningAgent:
         actions_in_state = self.actions_in_state
 
         if s in terminals:
-            Q[s, None] = r1
+            Q[s, None] = r
         if s is not None:
             Nsa[s, a] += 1
             Q[s, a] += alpha(Nsa[s, a]) * (r + gamma * max(Q[s1, a1]
@@ -330,7 +330,7 @@ class SARSALearningAgent(QLearningAgent):
         a1 = max(actions_in_state(s1), key=lambda a2: self.f(Q[s1, a2], Nsa[s1, a2]))
 
         if s in terminals:
-            Q[s, None] = r1
+            Q[s, None] = r
         if s is not None:
             Nsa[s, a] += 1
             # on-policy update: bootstrap on the actually-chosen next action a1


### PR DESCRIPTION
QLearningAgent (and SARSALearningAgent) set Q[s, None] = r1 (the new percept's reward) when the previous state was terminal, instead of r (the reward received at the terminal state) as in AIMA Fig 21.8. This made terminal Q-values wrong (≈-0.04/noisy instead of +1/-1) and produced incorrect policies. Fixed both; verified terminal Q-values now converge to ≈+1/-1 and the q-learning test passes. Fixes #1247.