### PR TITLE
Remove unused 'image' dependency from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 cvxopt
-image
 ipython
 ipythonblocks
 ipywidgets


### PR DESCRIPTION
The 'image' PyPI package is never imported anywhere in the codebase; PIL is provided by pillow (already in requirements.txt). Removing the obsolete dependency.